### PR TITLE
Feature/rake to seed domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,16 @@ ADMIN_ROLE_NAME=Administrator
 # Since the user accounts are not created by the users itselfs, but the
 # administrators, the password need to be auto-assigned
 DEFAULT_PASS=t3admin
+
+# The directory in which are stored the abstract classes (concepts) and the
+# predicates.
+#
+# This will be used to seed the database with the domains (abstract classes),
+# e.g. 'Person', 'Organization', and the predicates, which represents the
+# nature / quality of the mapping between the spine term and mapped term. E.g.
+# 'reworded', 'agreggated', 'identical', etc.
+
+#
+# Each file with its name ending with 'AbstractClasses.json' will be taken as
+# a representation of a domain set (also known as Concept Schema)
+CONCEPTS_DIRECTORY_PATH=concepts/

--- a/app/controllers/api/v1/domains_controller.rb
+++ b/app/controllers/api/v1/domains_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+###
+# @description: Place all the actions related to domains
+###
+class Api::V1::DomainsController < ApplicationController
+  ###
+  # @description: Lists all the domains
+  ###
+  def index
+    @domains = Domain.order(pref_label: :asc)
+
+    render json: @domains
+  end
+end

--- a/app/helpers/domain_helper.rb
+++ b/app/helpers/domain_helper.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+###
+# @description: This module will handle the tasks related to domains,
+#   which represents concepts.
+#
+#   E.g. "Person", "Organization", "Course"
+#
+#   One of the main tasks of this module will be to handle the existence
+#   of the domains by reading a skos file placed in a fixed directory in
+#   the project. That directory is configured by setting the environment
+#   variable called: "CONCEPTS_DIRECTORY_PATH"
+###
+module DomainHelper
+  ###
+  # @description: Process a given file which must contain json data, to
+  #   create domains and domain sets into the db.
+  # @param [File] file The already loaded json file to be processed
+  ###
+  def self.process_domains_from_file(file)
+    file_content = JSON.parse(file)
+
+    # The domains are listed under the '@graph' object
+    domains = file_content["@graph"]
+
+    # We want to differentiate a concept scheme, because it represents a domain set for us
+    domain_set = process_domain_set(domains)
+
+    # We need a domain set to relate all the domains to be created
+    raise "Concept Scheme object not found!" unless domain_set.present?
+
+    processed = process_domains(domains, domain_set)
+
+    p "#{ActionController::Base.helpers.pluralize(processed, 'domain')} processed." +
+    (
+      processed < 1 ? " Be sure to correctly format the file as an json-ld skos concepts file." : ""
+    )
+  end
+
+  ###
+  # @description: Process a given set of domains
+  # @param [Array] domains The domains to be processed. It's an array of
+  #   generic Objects
+  # @param [DomainSet] The domain set to be assigned as a parent for each
+  #   domain to be created
+  ###
+  def self.process_domains(domains, domain_set)
+    processed = 0
+    domains.each do |domain|
+      domain = domain.with_indifferent_access
+
+      # The concept scheme is processed, let's start with the proper domains
+      next if domain[:type] == "skos:ConceptScheme"
+
+      next if already_exists("Domain", domain)
+
+      Domain.create!({
+                       uri: domain[:id],
+                       pref_label: domain[:prefLabel]["en-us"],
+                       definition: domain[:definition]["en-us"],
+                       domain_set: domain_set
+                     })
+
+      processed += 1
+    end
+
+    processed
+  end
+
+  ###
+  # @description: Validate the existence of a domain / domain set in the database
+  #   with a message to console
+  # @param [String] object_class The class fr the object to validated
+  # @param [Object] object The object to validated, it's a generic object so the
+  #   class couldn't be inferred from it
+  ###
+  def self.already_exists(object_class, object)
+    exists = object_class.constantize.where(uri: object[:id]).count.positive?
+    p "#{object_class} with uri: '#{object[:id]}' already exists in our records, ignoring" if exists
+    exists
+  end
+
+  ###
+  # @description: Process a given concept shcheme (domain set) to crate it
+  #   if necessary
+  # @param [Object] domain The concept scheme object to be processed
+  ###
+  def self.process_domain_set(domains)
+    domain_set = domains.select {|d| d["type"] == "skos:ConceptScheme" }.first
+    domain_set = domain_set.with_indifferent_access
+
+    already_exists("DomainSet", domain_set)
+
+    DomainSet.first_or_create!({
+                                 uri: domain_set[:id],
+                                 title: domain_set[:title]["en-us"],
+                                 description: domain_set[:description]["en-us"],
+                                 creator: domain_set[:creator]["en-us"]
+                               })
+  end
+end

--- a/app/helpers/domains_helper.rb
+++ b/app/helpers/domains_helper.rb
@@ -31,7 +31,7 @@ module DomainsHelper
 
     processed = process_domains(domains, domain_set)
 
-    p "#{ActionController::Base.helpers.pluralize(processed, 'domain')} processed." +
+    puts "#{ActionController::Base.helpers.pluralize(processed, 'domain')} processed." +
     (
       processed < 1 ? " Be sure to correctly format the file as an json-ld skos concepts file." : ""
     )
@@ -76,7 +76,7 @@ module DomainsHelper
   ###
   def self.already_exists(object_class, object)
     exists = object_class.constantize.where(uri: object[:id]).count.positive?
-    p "#{object_class} with uri: '#{object[:id]}' already exists in our records, ignoring" if exists
+    puts "#{object_class} with uri: '#{object[:id]}' already exists in our records, ignoring" if exists
     exists
   end
 

--- a/app/helpers/domains_helper.rb
+++ b/app/helpers/domains_helper.rb
@@ -11,7 +11,7 @@
 #   the project. That directory is configured by setting the environment
 #   variable called: "CONCEPTS_DIRECTORY_PATH"
 ###
-module DomainHelper
+module DomainsHelper
   ###
   # @description: Process a given file which must contain json data, to
   #   create domains and domain sets into the db.

--- a/app/helpers/domains_helper.rb
+++ b/app/helpers/domains_helper.rb
@@ -52,7 +52,7 @@ module DomainsHelper
       # The concept scheme is processed, let's start with the proper domains
       next if domain[:type] == "skos:ConceptScheme"
 
-      next if already_exists("Domain", domain)
+      next if already_exists?(Domain, domain)
 
       Domain.create!({
                        uri: domain[:id],
@@ -74,8 +74,8 @@ module DomainsHelper
   # @param [Object] object The object to validated, it's a generic object so the
   #   class couldn't be inferred from it
   ###
-  def self.already_exists(object_class, object)
-    exists = object_class.constantize.where(uri: object[:id]).count.positive?
+  def self.already_exists?(object_class, object)
+    exists = object_class.exists?(uri: object[:id])
     puts "#{object_class} with uri: '#{object[:id]}' already exists in our records, ignoring" if exists
     exists
   end
@@ -89,7 +89,7 @@ module DomainsHelper
     domain_set = domains.select {|d| d["type"] == "skos:ConceptScheme" }.first
     domain_set = domain_set.with_indifferent_access
 
-    already_exists("DomainSet", domain_set)
+    already_exists?(DomainSet, domain_set)
 
     DomainSet.first_or_create!({
                                  uri: domain_set[:id],

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -89,9 +89,10 @@ const MappingForm = (props) => {
    * then put it in the local sate
    */
   const fillWithDomains = () => {
-    let domains = fetchDomains();
-    setDomains(domains);
-    setDomainId(domains[0].id);
+    let domains = fetchDomains().then((response) => {
+      setDomains(response);
+      setDomainId(response[0].id);
+    })
   }
 
   /**
@@ -184,7 +185,7 @@ const MappingForm = (props) => {
                       onChange={e => setDomainId(e.target.value)}
                     />
                     <label
-                      for={dom.id}
+                      htmlFor={dom.id}
                       className="form-check-label cursor-pointer"
                     >
                       {dom.name}

--- a/app/javascript/services/fetchDomains.jsx
+++ b/app/javascript/services/fetchDomains.jsx
@@ -1,20 +1,17 @@
-import abstractClasses from "../../../concepts/desmAbstractClasses.json"
+import apiService from "./apiService";
 
 const fetchDomains = () => {
-  /// Get the domains list from the file
-  let domains = abstractClasses["@graph"];
-
-  /// The first element does not represent a domain.
-  /// It's a Concept Scheme
-  domains.shift();
-
-  return domains.map((domain) => {
+  return apiService
+    .get("/api/v1/domains")
+    .then((response) => {
     /// From each domain in the list, we only need the id and the name
     /// in a simpler way
-    return {
-      id: domain.id,
-      name: domain.prefLabel["en-us"]
-    }
+    return response.data.map((domain) => {
+      return {
+        id: domain.uri,
+        name: domain.pref_label
+      }
+    })
   })
 }
 

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# @description: Represents a Concept, which is a domain from a Concept Scheme
+#   (also refered to as 'domain set'.
+#
+#   These concepts or domains are the entities related to the specifications
+#   trhre users uploads. In other words, a specification must be only for one
+#   domain, e.g.:
+#
+#   - Organization
+#   - Person
+#   - Course
+#
+#   These domains are, belongs to the "Desm Concept Scheme", which is a domain
+#   set.
+###
+class Domain < ApplicationRecord
+  belongs_to :domain_set
+  validates :uri, presence: true, uniqueness: true
+  validates :pref_label, presence: true
+end

--- a/app/models/domain_set.rb
+++ b/app/models/domain_set.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+###
+# @description: Represents a Concept Scheme, which is a set of domains
+#   (or concepts) to map to.
+#
+#   In the mapping process, at the beginnig, the user can pick which
+#   to map to. In a first use, the application will have only 1 set
+#   of domains, but It's also possible to have more than one set of
+#   domains by placing different skos files inside the 'ns' directory
+#
+#   There's a rake task that will feed the domain sets and domains by
+#   reading and parsing each file inside the mentioned directory.
+###
+class DomainSet < ApplicationRecord
+  validates :uri, presence: true, uniqueness: true
+  validates :title, presence: true
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -4,8 +4,8 @@
 # @description: Represents a role for a user in the application
 ###
 class Role < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
-
   has_many :assignments
   has_many :users, through: :assignments
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :roles, only: [:index]
+      get 'domains' => 'domains#index'
     end
   end
 

--- a/db/migrate/20200729164756_create_users.rb
+++ b/db/migrate/20200729164756_create_users.rb
@@ -3,8 +3,8 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
-      t.string :email
-      t.string :fullname
+      t.string :email, null: false
+      t.string :fullname, null: false
       t.string :password_digest
 
       t.timestamps

--- a/db/migrate/20200731215959_create_organizations.rb
+++ b/db/migrate/20200731215959_create_organizations.rb
@@ -3,7 +3,7 @@
 class CreateOrganizations < ActiveRecord::Migration[6.0]
   def change
     create_table :organizations do |t|
-      t.string :name
+      t.string :name, null: false
 
       t.timestamps
     end

--- a/db/migrate/20200801152958_create_roles.rb
+++ b/db/migrate/20200801152958_create_roles.rb
@@ -3,7 +3,7 @@
 class CreateRoles < ActiveRecord::Migration[6.0]
   def change
     create_table :roles do |t|
-      t.string :name
+      t.string :name, null: false
 
       t.timestamps
     end

--- a/db/migrate/20200828150609_create_domain_sets.rb
+++ b/db/migrate/20200828150609_create_domain_sets.rb
@@ -3,8 +3,8 @@
 class CreateDomainSets < ActiveRecord::Migration[6.0]
   def change
     create_table :domain_sets do |t|
-      t.string :title
-      t.string :uri
+      t.string :title, null: false
+      t.string :uri, null: false
       t.text :description
       t.string :creator
 

--- a/db/migrate/20200828150609_create_domain_sets.rb
+++ b/db/migrate/20200828150609_create_domain_sets.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateDomainSets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :domain_sets do |t|
+      t.string :title
+      t.string :uri
+      t.text :description
+      t.string :creator
+
+      t.timestamps
+    end
+
+    add_index :domain_sets, :uri, unique: true
+  end
+end

--- a/db/migrate/20200828155236_create_domains.rb
+++ b/db/migrate/20200828155236_create_domains.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateDomains < ActiveRecord::Migration[6.0]
+  def change
+    create_table :domains do |t|
+      t.string :pref_label
+      t.text :definition
+      t.string :uri
+      t.references :domain_set, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :domains, :uri, unique: true
+  end
+end

--- a/db/migrate/20200828155236_create_domains.rb
+++ b/db/migrate/20200828155236_create_domains.rb
@@ -3,9 +3,9 @@
 class CreateDomains < ActiveRecord::Migration[6.0]
   def change
     create_table :domains do |t|
-      t.string :pref_label
+      t.string :pref_label, null: false
+      t.string :uri, null: false
       t.text :definition
-      t.string :uri
       t.references :domain_set, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_150609) do
+ActiveRecord::Schema.define(version: 2020_08_28_155236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,17 @@ ActiveRecord::Schema.define(version: 2020_08_28_150609) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["uri"], name: "index_domain_sets_on_uri", unique: true
+  end
+
+  create_table "domains", force: :cascade do |t|
+    t.string "pref_label"
+    t.text "definition"
+    t.string "uri"
+    t.bigint "domain_set_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["domain_set_id"], name: "index_domains_on_domain_set_id"
+    t.index ["uri"], name: "index_domains_on_uri", unique: true
   end
 
   create_table "organizations", force: :cascade do |t|
@@ -59,4 +70,5 @@ ActiveRecord::Schema.define(version: 2020_08_28_150609) do
 
   add_foreign_key "assignments", "roles"
   add_foreign_key "assignments", "users"
+  add_foreign_key "domains", "domain_sets"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 2020_08_28_155236) do
   end
 
   create_table "domain_sets", force: :cascade do |t|
-    t.string "title"
-    t.string "uri"
+    t.string "title", null: false
+    t.string "uri", null: false
     t.text "description"
     t.string "creator"
     t.datetime "created_at", precision: 6, null: false
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2020_08_28_155236) do
   end
 
   create_table "domains", force: :cascade do |t|
-    t.string "pref_label"
+    t.string "pref_label", null: false
+    t.string "uri", null: false
     t.text "definition"
-    t.string "uri"
     t.bigint "domain_set_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -46,20 +46,20 @@ ActiveRecord::Schema.define(version: 2020_08_28_155236) do
   end
 
   create_table "organizations", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "roles", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email"
-    t.string "fullname"
+    t.string "email", null: false
+    t.string "fullname", null: false
     t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_01_153043) do
+ActiveRecord::Schema.define(version: 2020_08_28_150609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(version: 2020_08_01_153043) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["role_id"], name: "index_assignments_on_role_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"
+  end
+
+  create_table "domain_sets", force: :cascade do |t|
+    t.string "title"
+    t.string "uri"
+    t.text "description"
+    t.string "creator"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["uri"], name: "index_domain_sets_on_uri", unique: true
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,3 +20,7 @@ user_role = Role.create!(name: "Regular User");
 # Assing "admin" role to our admin user
 Assignment.create!(user: user, role: user_role);
 Assignment.create!(user: admin, role: admin_role);
+
+# Fill the db with all the domains (also called abstract classes or concepts) looking at
+# files in the 'concepts' directory
+Rake::Task['seeders:fetch_domains'].invoke

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - WEBPACKER_DEV_SERVER_HOST=webpack
       - ADMIN_ROLE_NAME=${ADMIN_ROLE_NAME}
       - DEFAULT_PASS=${DEFAULT_PASS}
+      - CONCEPTS_DIRECTORY_PATH=${CONCEPTS_DIRECTORY_PATH}
 
   db:
     image: postgres

--- a/lib/tasks/seeders.rake
+++ b/lib/tasks/seeders.rake
@@ -36,7 +36,7 @@ namespace :seeders do
         if option == "y"
           file = File.read(path + "/" + filename)
 
-          DomainHelper.process_domains_from_file(file)
+          DomainsHelper.process_domains_from_file(file)
 
           processed += 1
         end

--- a/lib/tasks/seeders.rake
+++ b/lib/tasks/seeders.rake
@@ -16,7 +16,7 @@ namespace :seeders do
   desc "Import the domains from the skos file/s placed inside the 'ns' directory"
   task fetch_domains: :environment do
     processed = 0
-    p "Existent domain sets and domains will be ignored. Do you want to proceed? (y/n)"
+    puts "Existent domain sets and domains will be ignored. Do you want to proceed? (y/n)"
     option = STDIN.gets.chomp
 
     if option == "y"
@@ -30,7 +30,7 @@ namespace :seeders do
         # Ensure we deal with a the file with classes
         next unless filename.downcase.include? "abstractclasses"
 
-        p "Do you want to process #{filename}?"
+        puts "Do you want to process #{filename}?"
         option = STDIN.gets.chomp
 
         if option == "y"
@@ -43,7 +43,7 @@ namespace :seeders do
       end
     end
 
-    p "#{ActionController::Base.helpers.pluralize(processed, 'file')} processed." +
+    puts "#{ActionController::Base.helpers.pluralize(processed, 'file')} processed." +
       (processed < 1 ? " Be sure to name the files ending with 'abstractclasses'." : "")
   end
 end

--- a/lib/tasks/seeders.rake
+++ b/lib/tasks/seeders.rake
@@ -14,13 +14,36 @@
 ###
 namespace :seeders do
   desc "Import the domains from the skos file/s placed inside the 'ns' directory"
-  task :fetch_domains do
-    # @todo:
-    #   - Check files inside 'ns' directory
-    #   - for each |file|
-    #   - check domain_set existence
-    #   - call the parser
-    #
-    #   - parser to check each domain inside the file
+  task fetch_domains: :environment do
+    processed = 0
+    p "Existent domain sets and domains will be ignored. Do you want to proceed? (y/n)"
+    option = STDIN.gets.chomp
+
+    if option == "y"
+      # Get the concepts directory path from the environment variables
+      path = File.join(Rails.root.to_s, "/", ENV.fetch("CONCEPTS_DIRECTORY_PATH"))
+
+      Dir.foreach(path) do |filename|
+        # Do not process the parent nor the current folder file representations
+        next if (filename == ".") || (filename == "..")
+
+        # Ensure we deal with a the file with classes
+        next unless filename.downcase.include? "abstractclasses"
+
+        p "Do you want to process #{filename}?"
+        option = STDIN.gets.chomp
+
+        if option == "y"
+          file = File.read(path + "/" + filename)
+
+          DomainHelper.process_domains_from_file(file)
+
+          processed += 1
+        end
+      end
+    end
+
+    p "#{ActionController::Base.helpers.pluralize(processed, 'file')} processed." +
+      (processed < 1 ? " Be sure to name the files ending with 'abstractclasses'." : "")
   end
 end

--- a/lib/tasks/seeders.rake
+++ b/lib/tasks/seeders.rake
@@ -21,9 +21,9 @@ namespace :seeders do
 
     if option == "y"
       # Get the concepts directory path from the environment variables
-      path = File.join(Rails.root.to_s, "/", ENV.fetch("CONCEPTS_DIRECTORY_PATH"))
+      path = Rails.root.join(ENV.fetch("CONCEPTS_DIRECTORY_PATH"))
 
-      Dir.foreach(path) do |filename|
+      Dir.foreach(path.to_s) do |filename|
         # Do not process the parent nor the current folder file representations
         next if (filename == ".") || (filename == "..")
 
@@ -34,7 +34,7 @@ namespace :seeders do
         option = STDIN.gets.chomp
 
         if option == "y"
-          file = File.read(path + "/" + filename)
+          file = File.read(path.join(filename))
 
           DomainsHelper.process_domains_from_file(file)
 

--- a/lib/tasks/seeders.rake
+++ b/lib/tasks/seeders.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+###
+# @description: Here we have all the tasks that indirectly feeds the db
+#   For some entities, we need to check files that are inside the project
+#   in the form of skos/json-ld.
+#
+#   We check those files and seed the DB if we found that the entities inside
+#   are not already in the application.
+#
+#   We have certainty of the existence of each of these entities by checking
+#   the URI, which in the skos files is called "@id", and we map it to the uri
+#   attribute of each entity.
+###
+namespace :seeders do
+  desc "Import the domains from the skos file/s placed inside the 'ns' directory"
+  task :fetch_domains do
+    # @todo:
+    #   - Check files inside 'ns' directory
+    #   - for each |file|
+    #   - check domain_set existence
+    #   - call the parser
+    #
+    #   - parser to check each domain inside the file
+  end
+end

--- a/spec/factories/domain_sets.rb
+++ b/spec/factories/domain_sets.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "faker"
+
+FactoryBot.define do
+  factory :domain_set do
+    title { Faker::App.name }
+    uri { Faker::Internet.url }
+    description { Faker::Lorem.sentence }
+    creator { Faker::App.author }
+  end
+end

--- a/spec/factories/domains.rb
+++ b/spec/factories/domains.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "faker"
+
+FactoryBot.define do
+  factory :domain do
+    pref_label { Faker::App.name }
+    definition { "MyText" }
+    uri { Faker::Lorem.sentence }
+    domain_set
+  end
+end

--- a/spec/models/domain_set_spec.rb
+++ b/spec/models/domain_set_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DomainSet, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:domain_set)).to be_valid
+  end
+
+  it { should validate_presence_of(:uri) }
+  it { should validate_presence_of(:title) }
+end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Domain, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:domain_set)).to be_valid
+  end
+
+  it { should validate_presence_of(:uri) }
+  it { should validate_presence_of(:pref_label) }
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -8,7 +8,6 @@ describe Role, type: :model do
   end
 
   it { should validate_presence_of(:name) }
-  it { should validate_uniqueness_of(:name) }
 
   it { should have_many(:assignments) }
   it { should have_many(:users).through(:assignments) }


### PR DESCRIPTION
# What was done?

    A rake task to seed domains is needed in order to
    read the json-ld skos files inside the 'concepts'
    directory.
    
    The rake task is configured to run from the database
    seeders (At the first use of the application).
    
    It will:
    - Look for each JSON file inside the 'concepts' directory.
    - It will validate the name of the file contains the
      'abstractclasses' string (upper, lower or mixed case).
    - Look for an object inside the '@graph' node with type
      'conceptScheme'inside the file to be the 'mapping set',
      or 'domain set' related to the list of domains.
    - If the conceptScheme is not found, it will raise an error.
    - If the concept scheme is present, it will try to create it,
      by storing it into the database.
    - If the concept scheme is present even in our records (might be
      the case of the subsequent calls of the rake task after the
      first one), it will ignore it.
    - It will iterate through each object inside the '@graph' node
      with the typ 'concept' and will try to store it into the
      database.
    - If any concept (domain) is already present in our records,
      it will just ignore it.
    
    The rake task can be called from the console by typing:
    - `rake seeders:fetch_domains`
    
# Diagrams
    The explanatory diagram for it is placed in the following url:
    https://miro.com/app/board/o9J_kna9728=/?moveToWidget=3074457349559146768&cot=6

# Screenshots
![image](https://user-images.githubusercontent.com/6996951/91637400-831dc800-e9de-11ea-8d23-7789c9756eb5.png)

![image](https://user-images.githubusercontent.com/6996951/91637408-9466d480-e9de-11ea-87f8-e4c03c369b5e.png)

