### PR TITLE
Feature/create mapping terms

### DIFF
--- a/app/assets/stylesheets/stepper.scss
+++ b/app/assets/stylesheets/stepper.scss
@@ -3,6 +3,7 @@
 
 .indicator{
   padding-left: 7vw;
+  margin-left: -5rem !important;
 }
 .indicator > .indicator-step {
   padding-left: 0.7vw;

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::MappingsController < ApplicationController
   end
 
   ###
-  # @description: Create a mapping with its related specification
+  # @description: Creates a mapping with its related specification
   ###
   def create
     spec = Specification.find(params[:specification_id])
@@ -25,6 +25,23 @@ class Api::V1::MappingsController < ApplicationController
     mapping = Processors::Mappings.create(spec, current_user) unless spec.spine?
 
     render json: mapping, include: :specification
+  end
+
+  ###
+  # @description: Creates the mapping terms. This method is used when the user has already
+  #   decided which terms to map to the spine
+  ###
+  def create_terms
+    # Validate mapping existence (We will create mapping terms for an existent mapping)
+    mapping = Mapping.find(params[:mapping_id])
+    terms = params[:terms]
+
+    raise ActiveRecord::RecordInvalid.new("Mapping terms were not provided") unless terms.count.positive?
+
+    # Proceed to create the mapping terms
+    Processors::Mappings.create_terms(mapping, terms)
+
+    render json: mapping, include: :terms
   end
 
   ###

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::MappingsController < ApplicationController
   # @description: Udates the attributes of a mapping
   ###
   def update
-    @mapping.update(permitted_params)
+    @mapping.update!(permitted_params)
 
     render json: {
       success: true,
@@ -48,7 +48,7 @@ class Api::V1::MappingsController < ApplicationController
     mapping = Mapping.find(params[:mapping_id])
     terms = params[:terms]
 
-    raise "Mapping terms were not provided" unless terms.count.positive?
+    raise "Mapping terms were not provided" unless terms.present? && terms.any?
 
     # Proceed to create the mapping terms
     Processors::Mappings.create_terms(mapping, terms)

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::MappingsController < ApplicationController
     mapping = Mapping.find(params[:mapping_id])
     terms = params[:terms]
 
-    raise ActiveRecord::RecordInvalid.new("Mapping terms were not provided") unless terms.count.positive?
+    raise "Mapping terms were not provided" unless terms.count.positive?
 
     # Proceed to create the mapping terms
     Processors::Mappings.create_terms(mapping, terms)

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -49,7 +49,7 @@ class Api::V1::MappingsController < ApplicationController
   #   in params
   ###
   def show
-    render json: @mapping
+    render json: @mapping, include: :terms
   end
 
   private

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -28,6 +28,18 @@ class Api::V1::MappingsController < ApplicationController
   end
 
   ###
+  # @description: Udates the attributes of a mapping
+  ###
+  def update
+    @mapping.update(permitted_params)
+
+    render json: {
+      success: true,
+      mapping: @mapping
+    }
+  end
+
+  ###
   # @description: Creates the mapping terms. This method is used when the user has already
   #   decided which terms to map to the spine
   ###
@@ -82,5 +94,13 @@ class Api::V1::MappingsController < ApplicationController
 
     # Return an ordered list
     mappings.order(title: :desc)
+  end
+
+  ###
+  # @description: Clean params
+  # @return [ActionController::Parameters]
+  ###
+  def permitted_params
+    params.require(:mapping).permit(:status)
   end
 end

--- a/app/controllers/concerns/recuperable.rb
+++ b/app/controllers/concerns/recuperable.rb
@@ -55,8 +55,13 @@ module Recuperable
   def self.define_errors
     {
       "RuntimeError": {
-        message_key: "errors.runtime",
+        message_key: "errors.general",
         status_code: :internal_server_error,
+        include_original_error_message: true
+      },
+      "ArgumentError": {
+        message_key: "errors.general",
+        status_code: :unprocessable_entity,
         include_original_error_message: true
       },
       "ActiveRecord::RecordNotFound": {

--- a/app/controllers/concerns/recuperable.rb
+++ b/app/controllers/concerns/recuperable.rb
@@ -54,6 +54,11 @@ module Recuperable
   ###
   def self.define_errors
     {
+      "RuntimeError": {
+        message_key: "errors.runtime",
+        status_code: :internal_server_error,
+        include_original_error_message: true
+      },
       "ActiveRecord::RecordNotFound": {
         message_key: "errors.not_found",
         status_code: :not_found,

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.js
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.js
@@ -191,6 +191,7 @@ const MappingToDomains = (props) => {
       <button
         className="btn bg-col-primary col-background"
         onClick={handleDomainMapping}
+        disabled={!mappedTerms.length}
       >
         Done Domain Mapping
       </button>
@@ -212,7 +213,7 @@ const MappingToDomains = (props) => {
         // @todo: Redirect to 3rd step mapping ("Align and Fine Tune")
       })
       .catch((e) => {
-        toast.error(e.message);
+        toast.error(e.response.data.message);
       });
   };
 

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.js
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.js
@@ -80,9 +80,23 @@ const MappingToDomains = (props) => {
   /**
    * The already mapped terms. To use in progress bar.
    */
-  const mappedTerms = terms.filter((term) => {
-    return term.mappedTo;
-  });
+  const mappedTerms = terms.filter(termIsMapped);
+
+  /**
+   * Returns wether the term is already mapped to the domain. It can be 1 of 2 options:
+   *
+   * 1. The term is recently dragged to the domain, so it's not in the backend, just
+   *    marked in memory as "mapped".
+   * 2. The term is already mapped in the backend (is one of the mapping terms in DB).
+   */
+  function termIsMapped(term) {
+    return (
+      term.mapped ||
+      mapping.terms.some((mappingTerm) => {
+        return mappingTerm.mapped_term_id === term.id;
+      })
+    );
+  }
 
   /**
    * The selected terms.
@@ -97,7 +111,7 @@ const MappingToDomains = (props) => {
   const afterDropTerm = (domain) => {
     let tempTerms = selectedTerms;
     tempTerms.forEach((termToMap) => {
-      termToMap.mappedTo = domain.uri;
+      termToMap.mapped = true;
       termToMap.selected = !termToMap.selected;
     });
     tempTerms = [...terms];
@@ -174,11 +188,11 @@ const MappingToDomains = (props) => {
    * Mark the term as "selected"
    */
   const onTermClick = (clickedTerm) => {
-    if(!clickedTerm.mappedTo){
+    if (!clickedTerm.mapped) {
       let tempTerms = [...terms];
       let term = tempTerms.find((t) => t.id == clickedTerm.id);
       term.selected = clickedTerm.selected;
-      
+
       setTerms(tempTerms);
     }
   };
@@ -348,13 +362,14 @@ const MappingToDomains = (props) => {
                         afterDrop={afterDropTerm}
                       >
                         {filteredTerms({ pickSelected: true }).map((term) => {
-                          return hideMapped && term.mappedTo ? (
+                          return hideMapped && termIsMapped(term) ? (
                             ""
                           ) : (
                             <TermCard
                               key={term.id}
                               term={term}
                               onClick={onTermClick}
+                              isMapped={termIsMapped}
                               onEditClick={onEditTermClick}
                             />
                           );
@@ -363,13 +378,14 @@ const MappingToDomains = (props) => {
 
                       {/* NOT SELECTED TERMS */}
                       {filteredTerms({ pickSelected: false }).map((term) => {
-                        return hideMapped && term.mappedTo ? (
+                        return hideMapped && termIsMapped(term) ? (
                           ""
                         ) : (
                           <TermCard
                             key={term.id}
                             term={term}
                             onClick={onTermClick}
+                            isMapped={termIsMapped}
                             onEditClick={onEditTermClick}
                           />
                         );

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.js
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.js
@@ -11,6 +11,8 @@ import EditTerm from "./EditTerm";
 import TermCardsContainer from "./TermCardsContainer";
 import fetchSpecification from "../../services/fetchSpecification";
 import fetchSpecificationTerms from "../../services/fetchSpecificationTerms";
+import createMappingTerms from "../../services/createMappingTerms";
+import { toastr as toast } from "react-redux-toastr";
 
 const MappingToDomains = (props) => {
   /**
@@ -90,14 +92,6 @@ const MappingToDomains = (props) => {
   });
 
   /**
-   * The already mapped terms to a given domain.
-   */
-  const mappedTermsToDomain = (domainUri) =>
-    terms.filter((term) => {
-      return term.mappedTo == domainUri;
-    });
-
-  /**
    * Action to perform after a term is dropped
    */
   const afterDropTerm = (domain) => {
@@ -130,6 +124,7 @@ const MappingToDomains = (props) => {
         mapSpecification={true}
         stepper={true}
         stepperStep={2}
+        customcontent={<DoneDomainMapping />}
       />
     );
   };
@@ -179,11 +174,46 @@ const MappingToDomains = (props) => {
    * Mark the term as "selected"
    */
   const onTermClick = (clickedTerm) => {
-    let tempTerms = [...terms];
-    let term = tempTerms.find((t) => t.id == clickedTerm.id);
-    term.selected = clickedTerm.selected;
+    if(!clickedTerm.mappedTo){
+      let tempTerms = [...terms];
+      let term = tempTerms.find((t) => t.id == clickedTerm.id);
+      term.selected = clickedTerm.selected;
+      
+      setTerms(tempTerms);
+    }
+  };
 
-    setTerms(tempTerms);
+  /**
+   * Button to accept the mapping, create teh mapping terms and go to the next screen
+   */
+  const DoneDomainMapping = () => {
+    return (
+      <button
+        className="btn bg-col-primary col-background"
+        onClick={handleDomainMapping}
+      >
+        Done Domain Mapping
+      </button>
+    );
+  };
+
+  /**
+   * Create the mapping terms
+   */
+  const handleDomainMapping = () => {
+    createMappingTerms({
+      mappingId: mapping.id,
+      terms: mappedTerms,
+    })
+      .then((response) => {
+        toast.success(
+          mappedTerms.length + " mapping terms created successfully"
+        );
+        // @todo: Redirect to 3rd step mapping ("Align and Fine Tune")
+      })
+      .catch((e) => {
+        toast.error(e.message);
+      });
   };
 
   /**
@@ -250,16 +280,13 @@ const MappingToDomains = (props) => {
                     {!loading && (
                       <DomainCard
                         domain={domain}
-                        mappedTerms={mappedTermsToDomain(domain.id)}
+                        mappedTerms={mappedTerms}
                         selectedTermsCount={selectedTerms.length}
                       />
                     )}
                   </div>
-                  <div className="mt-2">
-                    <button className="btn bg-col-primary col-background">
-                      Done Domain Mapping
-                    </button>
-                  </div>
+                  <div className="mt-2"></div>
+                  {<DoneDomainMapping />}
                 </div>
 
                 {/* RIGHT SIDE */}

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.js
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.js
@@ -11,7 +11,7 @@ import EditTerm from "./EditTerm";
 import TermCardsContainer from "./TermCardsContainer";
 import fetchSpecification from "../../services/fetchSpecification";
 import fetchSpecificationTerms from "../../services/fetchSpecificationTerms";
-import createMappingTerms from "../../services/createMappingTerms";
+import saveMappingTerms from "../../services/saveMappingTerms";
 import { toastr as toast } from "react-redux-toastr";
 
 const MappingToDomains = (props) => {
@@ -34,6 +34,11 @@ const MappingToDomains = (props) => {
    * Whether the page is loading results or not
    */
   const [loading, setLoading] = useState(true);
+
+  /**
+   * Whether any change awas performed after the page loads
+   */
+  const [anyTermMapped, setAnyTermMapped] = useState(false);
 
   /**
    * Whether to hide mapped terms or not
@@ -116,6 +121,7 @@ const MappingToDomains = (props) => {
     });
     tempTerms = [...terms];
     setTerms(tempTerms);
+    setAnyTermMapped(true);
   };
 
   /**
@@ -204,7 +210,7 @@ const MappingToDomains = (props) => {
     return (
       <button
         className="btn bg-col-primary col-background"
-        onClick={handleDomainMapping}
+        onClick={handleSaveChanges}
         disabled={!mappedTerms.length}
       >
         Done Domain Mapping
@@ -213,18 +219,23 @@ const MappingToDomains = (props) => {
   };
 
   /**
+   * Comain mappping complete. Confirm to save status in the backend
+   */
+  const handleDoneDomainMapping = () => {
+    // @todo: Redirect to 3rd step mapping ("Align and Fine Tune")
+  };
+
+  /**
    * Create the mapping terms
    */
-  const handleDomainMapping = () => {
-    createMappingTerms({
+  const handleSaveChanges = () => {
+    saveMappingTerms({
       mappingId: mapping.id,
       terms: mappedTerms,
     })
       .then((response) => {
-        toast.success(
-          mappedTerms.length + " mapping terms created successfully"
-        );
-        // @todo: Redirect to 3rd step mapping ("Align and Fine Tune")
+        toast.success("Changes saved");
+        setAnyTermMapped(false);
       })
       .catch((e) => {
         toast.error(e.response.data.message);
@@ -302,6 +313,13 @@ const MappingToDomains = (props) => {
                   </div>
                   <div className="mt-2"></div>
                   {<DoneDomainMapping />}
+                  <button
+                    className="btn btn-dark ml-3"
+                    onClick={handleSaveChanges}
+                    disabled={!anyTermMapped}
+                  >
+                    Save Changes
+                  </button>
                 </div>
 
                 {/* RIGHT SIDE */}

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.js
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.js
@@ -13,6 +13,7 @@ import fetchSpecification from "../../services/fetchSpecification";
 import fetchSpecificationTerms from "../../services/fetchSpecificationTerms";
 import saveMappingTerms from "../../services/saveMappingTerms";
 import { toastr as toast } from "react-redux-toastr";
+import updateMapping from "../../services/updateMapping";
 
 const MappingToDomains = (props) => {
   /**
@@ -210,7 +211,7 @@ const MappingToDomains = (props) => {
     return (
       <button
         className="btn bg-col-primary col-background"
-        onClick={handleSaveChanges}
+        onClick={handleDoneDomainMapping}
         disabled={!mappedTerms.length}
       >
         Done Domain Mapping
@@ -221,7 +222,11 @@ const MappingToDomains = (props) => {
   /**
    * Comain mappping complete. Confirm to save status in the backend
    */
-  const handleDoneDomainMapping = () => {
+  const handleDoneDomainMapping = async () => {
+    await updateMapping({ id: mapping.id, status: "mapped" });
+    if (anyTermMapped){
+      handleSaveChanges();
+    }
     // @todo: Redirect to 3rd step mapping ("Align and Fine Tune")
   };
 
@@ -233,7 +238,7 @@ const MappingToDomains = (props) => {
       mappingId: mapping.id,
       terms: mappedTerms,
     })
-      .then((response) => {
+      .then(() => {
         toast.success("Changes saved");
         setAnyTermMapped(false);
       })

--- a/app/javascript/components/mapping-to-domains/TermCard.jsx
+++ b/app/javascript/components/mapping-to-domains/TermCard.jsx
@@ -16,29 +16,31 @@ export default class TermCard extends Component {
    * selected or not selected
    */
   handleTermClick = () => {
-    const { selected, animationDuration } = this.state;
-    // Trigger animation
-    this.setState(
-      ({ animationisVisible }) => ({
-        animationisVisible: !animationisVisible,
-      }),
-      () => {
-        // Await until the animation finishes. Otherwise the term just roughly dissapears
-        setTimeout(() => {
-          // local value (this term)
-          this.setState(
-            ({ selected }) => ({
-              selected: !selected,
-            }),
-            () => {
-              // props value (the term inside the list in the parent component)
-              this.props.term.selected = !this.props.term.selected;
-              this.props.onClick(this.props.term);
-            }
-          );
-        }, animationDuration);
-      }
-    );
+    if (!this.props.term.mappedTo) {
+      const { selected, animationDuration } = this.state;
+      // Trigger animation
+      this.setState(
+        ({ animationisVisible }) => ({
+          animationisVisible: !animationisVisible,
+        }),
+        () => {
+          // Await until the animation finishes. Otherwise the term just roughly dissapears
+          setTimeout(() => {
+            // local value (this term)
+            this.setState(
+              ({ selected }) => ({
+                selected: !selected,
+              }),
+              () => {
+                // props value (the term inside the list in the parent component)
+                this.props.term.selected = !this.props.term.selected;
+                this.props.onClick(this.props.term);
+              }
+            );
+          }, animationDuration);
+        }
+      );
+    }
   };
 
   render() {

--- a/app/javascript/components/mapping-to-domains/TermCard.jsx
+++ b/app/javascript/components/mapping-to-domains/TermCard.jsx
@@ -16,7 +16,7 @@ export default class TermCard extends Component {
    * selected or not selected
    */
   handleTermClick = () => {
-    if (!this.props.term.mappedTo) {
+    if (!this.props.isMapped(this.props.term)) {
       const { selected, animationDuration } = this.state;
       // Trigger animation
       this.setState(
@@ -56,7 +56,7 @@ export default class TermCard extends Component {
         <div
           className={
             "card with-shadow mb-2" +
-            (this.props.term.mappedTo
+            (this.props.isMapped(this.props.term)
               ? " disabled-container not-draggable"
               : selected
               ? " draggable term-selected"
@@ -73,7 +73,7 @@ export default class TermCard extends Component {
               </div>
               <div className="col-4">
                 <div className="float-right">
-                  {this.props.term.mappedTo ? (
+                  {this.props.isMapped(this.props.term) ? (
                     <i className="fas fa-check"></i>
                   ) : (
                     <React.Fragment>

--- a/app/javascript/components/shared/Loader.jsx
+++ b/app/javascript/components/shared/Loader.jsx
@@ -1,4 +1,3 @@
-import { checkPropTypes } from "prop-types";
 import React from "react";
 
 const Loader = (props) => {

--- a/app/javascript/components/shared/TopNavOptions.jsx
+++ b/app/javascript/components/shared/TopNavOptions.jsx
@@ -1,36 +1,41 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import Stepper from './../mapping/Stepper';
+import React from "react";
+import { Link } from "react-router-dom";
+import Stepper from "./../mapping/Stepper";
 
 const TopNavOptions = (props) => {
   return (
-    <ul className="navbar-nav mr-auto">
-      {
-        props.viewMappings &&
-        <li className="nav-item current-page mt-0 mb-1 ml-0 ml-lg-3 mr-0 mr-lg-3">
-          <Link to="/specifications" className="nav-link nav-title-highlited">
-            View Mappings
-          </Link>
+    <React.Fragment>
+      <ul className="navbar-nav mr-auto">
+        {props.viewMappings && (
+          <li className="nav-item current-page mt-0 mb-1 ml-0 ml-lg-3 mr-0 mr-lg-3">
+            <Link to="/specifications" className="nav-link nav-title-highlited">
+              View Mappings
+            </Link>
+          </li>
+        )}
+        {props.mapSpecification && (
+          <li className="mt-0 mb-1 ml-0 ml-lg-3 mr-0 mr-lg-3">
+            <Link
+              to="/new-mapping"
+              className="btn wide-btn btn-outline-secondary"
+            >
+              Map a Specification
+            </Link>
+          </li>
+        )}
+        {props.stepper && (
+          <li>
+            <Stepper stepperStep={props.stepperStep} />
+          </li>
+        )}
+      </ul>
+      <ul className="navbar-nav mr-auto">
+        <li className="mt-0 mb-2 ml-0 ml-lg-3 mr-0 mr-lg-3">
+          {props.customcontent}
         </li>
-      }
-      {
-        props.mapSpecification &&
-        <li className="mt-0 mb-1 ml-0 ml-lg-3 mr-0 mr-lg-3">
-          <Link to="/new-mapping" className="btn wide-btn btn-outline-secondary">
-            Map a Specification
-          </Link>
-        </li>
-      }
-      {
-        props.stepper &&
-        <li>
-          <Stepper 
-            stepperStep={props.stepperStep}
-          />
-        </li>
-      }
-    </ul>
+      </ul>
+    </React.Fragment>
   );
-}
+};
 
 export default TopNavOptions;

--- a/app/javascript/services/createMappingTerms.jsx
+++ b/app/javascript/services/createMappingTerms.jsx
@@ -1,0 +1,11 @@
+import apiService from "./apiService";
+
+const createMappingTerms = async (data) => {
+  const response = await apiService.post("/api/v1/mappings/terms", {
+    terms: data.terms,
+    mapping_id: data.mappingId,
+  });
+  return response.data;
+};
+
+export default createMappingTerms;

--- a/app/javascript/services/saveMappingTerms.jsx
+++ b/app/javascript/services/saveMappingTerms.jsx
@@ -1,6 +1,6 @@
 import apiService from "./apiService";
 
-const createMappingTerms = async (data) => {
+const saveMappingTerms = async (data) => {
   const response = await apiService.post("/api/v1/mappings/terms", {
     terms: data.terms,
     mapping_id: data.mappingId,
@@ -8,4 +8,4 @@ const createMappingTerms = async (data) => {
   return response.data;
 };
 
-export default createMappingTerms;
+export default saveMappingTerms;

--- a/app/javascript/services/updateMapping.js
+++ b/app/javascript/services/updateMapping.js
@@ -1,0 +1,16 @@
+import apiService from "./apiService";
+
+const updateMapping = async (mapping) => {
+  const response = await apiService.put(
+    "/api/v1/mappings/" + mapping.id,
+    mapping
+  );
+  if (response.status === 200) {
+    return {
+      success: true,
+    };
+  }
+  return { success: false };
+};
+
+export default updateMapping;

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -13,4 +13,9 @@ class Mapping < ApplicationRecord
   belongs_to :spine, foreign_key: "spine_id", class_name: :Specification
   has_many :terms, class_name: :MappingTerm
   validates :name, presence: true
+
+  # The possible status of a mapping
+  # 1. "uploaded" This means there's a specification uploaded but not terms mapped
+  # 2. "mapped" It means the terms are confirmed as mapped to the spine
+  enum status: %i[uploaded mapped]
 end

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -10,6 +10,7 @@
 class Mapping < ApplicationRecord
   belongs_to :user
   belongs_to :specification
-  belongs_to :spine, foreign_key: "spine_id", class_name: "Specification"
+  belongs_to :spine, foreign_key: "spine_id", class_name: :Specification
+  has_many :terms, class_name: :MappingTerm
   validates :name, presence: true
 end

--- a/app/models/mapping_term.rb
+++ b/app/models/mapping_term.rb
@@ -4,14 +4,14 @@
 # @description: Represents a mapping term, which is each of terms resulting of
 #   a merge between 2 specifications.
 #
-#   It's created when the user uploads a specification for a domain which
-#   already has a spine (a previous specification was uploaded for it).
+#   It's created when the user selects a term from the specification to map
+#   against the spine.
 ###
 class MappingTerm < ApplicationRecord
   belongs_to :mapping
   belongs_to :predicate
-  has_one :spine_term, foreign_key: "spine_term_id", class_name: "Term"
-  has_one :mapped_term, foreign_key: "mapped_term_id", class_name: "Term"
+  belongs_to :spine_term, foreign_key: "spine_term_id", class_name: "Term"
+  belongs_to :mapped_term, foreign_key: "mapped_term_id", class_name: "Term"
 
   validates :uri, presence: true
 end

--- a/app/models/mapping_term.rb
+++ b/app/models/mapping_term.rb
@@ -9,8 +9,8 @@
 ###
 class MappingTerm < ApplicationRecord
   belongs_to :mapping
-  belongs_to :predicate
-  belongs_to :spine_term, foreign_key: "spine_term_id", class_name: "Term"
+  belongs_to :predicate, optional: true
+  belongs_to :spine_term, foreign_key: "spine_term_id", class_name: "Term", optional: true
   belongs_to :mapped_term, foreign_key: "mapped_term_id", class_name: "Term"
 
   validates :uri, presence: true

--- a/app/policies/mapping_policy.rb
+++ b/app/policies/mapping_policy.rb
@@ -38,4 +38,12 @@ class MappingPolicy < ApplicationPolicy
   def create?
     @user.present?
   end
+
+  ###
+  # @description: Determines if the user can create an instance of this resource
+  # @return [TrueClass]
+  ###
+  def create_terms?
+    @user.present?
+  end
 end

--- a/app/policies/mapping_policy.rb
+++ b/app/policies/mapping_policy.rb
@@ -46,4 +46,12 @@ class MappingPolicy < ApplicationPolicy
   def create_terms?
     @user.present?
   end
+
+  ###
+  # @description: Determines if the user can update an instance of this resource
+  # @return [TrueClass]
+  ###
+  def update?
+    @user.present?
+  end
 end

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -35,9 +35,13 @@ module Processors
     def self.create_terms(mapping, terms)
       terms.each do |term|
         term = Term.find(term[:id])
+        custom_uri = "desm:#{term.uri}"
+
+        # Do not create this term if there's already one with the same uri
+        next if MappingTerm.find_by(uri: custom_uri)
 
         MappingTerm.create!(
-          uri: "desm:#{term.uri}",
+          uri: custom_uri,
           mapping: mapping,
           mapped_term_id: term.id
         )

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -30,21 +30,23 @@ module Processors
     # @params [Array] terms: The list of terms as an array of objects. These are the
     #   specification terms, selected to be mapped against the spine.
     #
-    # @return [Mapping]
+    # @return [Array]
     ###
     def self.create_terms(mapping, terms)
-      terms.each do |term|
-        term = Term.find(term[:id])
-        custom_uri = "desm:#{term.uri}"
+      ActiveRecord::Base.transaction do
+        terms.each do |term|
+          term = Term.find(term[:id])
+          custom_uri = "desm:#{term.uri}"
 
-        # Do not create this term if there's already one with the same uri
-        next if MappingTerm.find_by(uri: custom_uri)
+          # Do not create this term if there's already one with the same uri
+          next if MappingTerm.find_by(uri: custom_uri)
 
-        MappingTerm.create!(
-          uri: custom_uri,
-          mapping: mapping,
-          mapped_term_id: term.id
-        )
+          MappingTerm.create!(
+            uri: custom_uri,
+            mapping: mapping,
+            mapped_term_id: term.id
+          )
+        end
       end
     end
   end

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -23,5 +23,25 @@ module Processors
       )
       m
     end
+
+    ###
+    # @description: Creates the terms for the mapping.
+    # @param [Mapping] mapping: The mapping for which the terms are going to be created.
+    # @params [Array] terms: The list of terms as an array of objects. These are the
+    #   specification terms, selected to be mapped against the spine.
+    #
+    # @return [Mapping]
+    ###
+    def self.create_terms(mapping, terms)
+      terms.each do |term|
+        term = Term.find(term[:id])
+
+        MappingTerm.create!(
+          uri: "desm:#{term.uri}",
+          mapping: mapping,
+          mapped_term_id: term.id
+        )
+      end
+    end
   end
 end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -1,5 +1,6 @@
 en:
   errors:
+    runtime: "Atention: %{message}"
     not_found: "Record not found"
     record_invalid: "Invalid: %{message}"
     record_not_destroyed: "Can't delete: %{message}"

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -1,6 +1,6 @@
 en:
   errors:
-    runtime: "Atention: %{message}"
+    general: "Atention: %{message}"
     not_found: "Record not found"
     record_invalid: "Invalid: %{message}"
     record_not_destroyed: "Can't delete: %{message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :domains, only: [:index, :show]
-      resources :mappings, only: [:create, :show, :index]
+      resources :mappings, only: [:create, :show, :index, :update]
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :roles, only: [:index]
       resources :specifications, only: [:create, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :terms, only: [:show, :update, :destroy]
       resources :vocabularies, only: [:index, :create]
 
+      post 'mappings/terms' => 'mappings#create_terms'
       post 'specifications/info' => 'specifications#info'
       post 'specifications/filter' => 'specifications#filter'
       get 'specifications/:id/terms' => 'terms#from_specification'

--- a/db/migrate/20201001134619_remove_not_null_constraint_from_mapping_terms_predicate_field.rb
+++ b/db/migrate/20201001134619_remove_not_null_constraint_from_mapping_terms_predicate_field.rb
@@ -2,6 +2,6 @@
 
 class RemoveNotNullConstraintFromMappingTermsPredicateField < ActiveRecord::Migration[6.0]
   def change
-    change_column :mapping_terms, :predicate_id, :integer, null: true
+    change_column :mapping_terms, :predicate_id, :bigint, null: true
   end
 end

--- a/db/migrate/20201001134619_remove_not_null_constraint_from_mapping_terms_predicate_field.rb
+++ b/db/migrate/20201001134619_remove_not_null_constraint_from_mapping_terms_predicate_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNotNullConstraintFromMappingTermsPredicateField < ActiveRecord::Migration[6.0]
+  def change
+    change_column :mapping_terms, :predicate_id, :integer, null: true
+  end
+end

--- a/db/migrate/20201001204710_add_satus_to_mappings.rb
+++ b/db/migrate/20201001204710_add_satus_to_mappings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSatusToMappings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mappings, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_28_232021) do
+ActiveRecord::Schema.define(version: 2020_10_01_134619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2020_09_28_232021) do
     t.string "uri"
     t.text "comment"
     t.bigint "mapping_id", null: false
-    t.bigint "predicate_id", null: false
+    t.integer "predicate_id"
     t.integer "spine_term_id"
     t.integer "mapped_term_id"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_204710) do
     t.string "uri"
     t.text "comment"
     t.bigint "mapping_id", null: false
-    t.integer "predicate_id"
+    t.bigint "predicate_id"
     t.integer "spine_term_id"
     t.integer "mapped_term_id"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_134619) do
+ActiveRecord::Schema.define(version: 2020_10_01_204710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_134619) do
     t.integer "spine_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
     t.index ["specification_id"], name: "index_mappings_on_specification_id"
     t.index ["user_id"], name: "index_mappings_on_user_id"
   end


### PR DESCRIPTION
# What was done?

### Create the mapping terms after clicking "Done Domain Mapping"

- Send the mapped terms to assign the terms to the mapping, so we can prepare for the next screen.

### Add a status for the mappings

### Correctly draw the terms that were added to domains

- In the mapping to domains view, after clicking on the "Done Domain Mapping" button, the mapping terms are successfully created, but the next page load, the terms are again "unmapped".
- Those specification "mapped" terms are the ones that are "in-memory" marked as "mapped" and also those that are referenced by the current mapping terms as "mapped_spec_terms".

### In order to know what to draw when resuming a mapping, 2 statuses were added:

1. uploaded: When a specification was uploaded, a mapping is created without any terms.
2. mapped: When all the terms are mapped and the user marked the mapping as "ready to be aligned" by clicking on the "Donde Domain Mapping" button.