### PR TITLE
Refactor to integrate format converter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "rack-cors", require: "rack/cors"
 # Manage authorization
 gem "pundit"
 
+# For http requests
+gem "httparty"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -108,11 +111,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
+    multi_xml (0.6.0)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -253,6 +260,7 @@ DEPENDENCIES
   capybara
   factory_bot_rails
   faker
+  httparty
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/assets/stylesheets/stepper.scss
+++ b/app/assets/stylesheets/stepper.scss
@@ -4,6 +4,8 @@
 .indicator{
   padding-left: 7vw;
   margin-left: -5rem !important;
+  bottom: 0.5rem;
+  position: relative;
 }
 .indicator > .indicator-step {
   padding-left: 0.7vw;

--- a/app/controllers/concerns/connectable.rb
+++ b/app/controllers/concerns/connectable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+###
+# @description: Gives the ability to get the current user data if there's any
+###
+module Connectable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    ###
+    # @description: Determines whether a string corresponds to a URI or not
+    # @param [String]: The string to be evaluated
+    # @return [TrueClass|FalseClass]
+    ###
+    def uri?(string)
+      uri = URI.parse(string)
+      %w[http https].include?(uri.scheme)
+    rescue URI::BadURIError
+      false
+    rescue URI::InvalidURIError
+      false
+    end
+
+    ###
+    # @description: The context or another needed resource may be a reference to an external json service.
+    #  In those cases we fetch the content from that service.
+    # @param [String] uri: The http address to fetch the content from
+    # @return [String]
+    ###
+    def http_get uri
+      HTTParty.get(uri)
+    end
+  end
+end

--- a/app/javascript/actions/files.jsx
+++ b/app/javascript/actions/files.jsx
@@ -45,3 +45,27 @@ export const unsetSpecToPreview = (specs) => {
     payload: specs,
   };
 };
+
+/**
+ * Represents setting the merged file to valid unified file, containing
+ * the user selected files as only one
+ *
+ * @returns {Array}
+ */
+export const setMergedFile = (file) => {
+  return {
+    type: "SET_MERGED_FILE",
+    payload: file,
+  };
+};
+
+/**
+ * Represents setting the merged file to an empty object
+ *
+ * @returns {Array}
+ */
+export const unsetMergedFile = () => {
+  return {
+    type: "UNSET_MERGED_FILE",
+  };
+};

--- a/app/javascript/actions/vocabularies.jsx
+++ b/app/javascript/actions/vocabularies.jsx
@@ -1,0 +1,22 @@
+/**
+ * Represents setting the vocabularies when the user uploads the files
+ *
+ * @returns {Array}
+ */
+export const setVocabularies = (vocabularies) => {
+  return {
+    type: "SET_VOCABULARIES",
+    payload: vocabularies,
+  };
+};
+
+/**
+ * Represents setting the vocabularies to an empty array
+ *
+ * @returns {Array}
+ */
+export const unsetVocabularies = () => {
+  return {
+    type: "UNSET_VOCABULARIES",
+  };
+};

--- a/app/javascript/components/mapping-to-domains/EditTerm.jsx
+++ b/app/javascript/components/mapping-to-domains/EditTerm.jsx
@@ -48,6 +48,10 @@ export default class EditTerm extends Component {
    * @param {Array} domains
    */
   domainsAsOptions = (domains) => {
+    if (!_.isArray(domains)) {
+      domains = [domains];
+    }
+
     return domains
       ? domains.map((domain) => {
           return {
@@ -59,11 +63,41 @@ export default class EditTerm extends Component {
   };
 
   /**
+   * Returns the currently selected domain for a term
+   * 
+   * @param {Array|String} domains 
+   */
+  setSelectedDomain = (domains) => {
+    if (!_.isArray(domains)) {
+      return domains;
+    }
+
+    domains.find((d) => d === this.state.term.property.selected_domain);
+  };
+
+  /**
+   * Returns the currently selected range for a term
+   * 
+   * @param {Array|String} range 
+   */
+  setSelectedRange = (range) => {
+    if (!_.isArray(range)) {
+      return range;
+    }
+
+    range.find((r) => r === this.state.term.property.selected_range);
+  };
+
+  /**
    * Prepare the domains of a term to be listed as options for the expandable component
    *
    * @param {Array} domains
    */
   rangeAsOptions = (range) => {
+    if (!_.isArray(range)) {
+      range = [range];
+    }
+
     return range
       ? range.map((rng) => {
           return {
@@ -339,8 +373,8 @@ export default class EditTerm extends Component {
                         options={this.domainsAsOptions(
                           this.state.term.property.domain
                         )}
-                        selectedOption={this.state.term.property.domain.find(
-                          (d) => d === this.state.term.property.selected_domain
+                        selectedOption={this.setSelectedDomain(
+                          this.state.term.property.domain
                         )}
                         onClose={(domain) => this.handleDomainChange(domain.id)}
                       />
@@ -353,8 +387,8 @@ export default class EditTerm extends Component {
                         options={this.rangeAsOptions(
                           this.state.term.property.range
                         )}
-                        selectedOption={this.state.term.property.range.find(
-                          (r) => r === this.state.term.property.selected_range
+                        selectedOption={this.setSelectedRange(
+                          this.state.term.property.range
                         )}
                         onClose={(range) => this.handleRangeChange(range.id)}
                       />

--- a/app/javascript/components/mapping/FileContent.jsx
+++ b/app/javascript/components/mapping/FileContent.jsx
@@ -1,25 +1,55 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import "react-tabs/style/react-tabs.css";
 
 /**
  * Reads the file content
  */
 const FileContent = () => {
   const previewSpecs = useSelector((state) => state.previewSpecs);
+  const vocabularies = useSelector((state) => state.vocabularies);
 
   return (
     <React.Fragment>
-      {previewSpecs.map((content, i) => {
-        return (
-          <div className="card mt-2 mb-2 has-scrollbar scrollbar" key={i}>
-            <div className="card-body">
-              <pre>
-                <code>{content}</code>
-              </pre>
-            </div>
-          </div>
-        );
-      })}
+      <Tabs>
+        <TabList>
+          {previewSpecs.map((content, i) => {
+            return <Tab key={i}>{"Spec"}</Tab>
+          })}
+          {vocabularies.map((content, i) => {
+            return <Tab key={i}>{"Vocab " + (i + 1)}</Tab>;
+          })}
+        </TabList>
+
+        {previewSpecs.map((content, i) => {
+          return (
+            <TabPanel key={i}>
+              <div className="card mt-2 mb-2 has-scrollbar scrollbar">
+                <div className="card-body">
+                  <pre>
+                    <code>{content}</code>
+                  </pre>
+                </div>
+              </div>
+            </TabPanel>
+          );
+        })}
+
+        {vocabularies.map((content, i) => {
+          return (
+            <TabPanel key={i}>
+              <div className="card mt-2 mb-2 has-scrollbar scrollbar">
+                <div className="card-body">
+                  <pre>
+                    <code>{JSON.stringify(content, null, 2)}</code>
+                  </pre>
+                </div>
+              </div>
+            </TabPanel>
+          );
+        })}
+      </Tabs>
     </React.Fragment>
   );
 };

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -3,7 +3,7 @@ import validator from "validator";
 import AlertNotice from "../shared/AlertNotice";
 import FileInfo from "./FileInfo";
 import { useSelector, useDispatch } from "react-redux";
-import { setFiles, setSpecToPreview } from "../../actions/files";
+import { setFiles, setMergedFile, setSpecToPreview } from "../../actions/files";
 import {
   doSubmit,
   startProcessingFile,
@@ -15,6 +15,8 @@ import { toastr as toast } from "react-redux-toastr";
 import MultipleDomainsModal from "./MultipleDomainsModal";
 import checkDomainsInFile from "../../services/checkDomainsInFile";
 import filterSpecification from "../../services/filterSpecification";
+import mergeFiles from "../../services/mergeFiles";
+import { setVocabularies } from "../../actions/vocabularies";
 
 const MappingForm = () => {
   const [errors, setErrors] = useState("");
@@ -53,6 +55,9 @@ const MappingForm = () => {
 
   /// The files uploaded by the user
   const files = useSelector((state) => state.files);
+
+  /// The unified file from the ones the user uploaded
+  const mergedFile = useSelector((state) => state.mergedFile);
 
   /// The preview files (files already prepared to be previewed, as
   /// without the unrelated domains and properties)
@@ -139,41 +144,97 @@ const MappingForm = () => {
   };
 
   /**
+   * Unify the files by using the service
+   * If we recognize more than 1 file uploaded by the user, we use the service to
+   * merge the files into one big graph. And from now on, we manage to work with
+   * the file content and not with the file object/s.
+   *
+   * Note that if there's only one file, nothing changes. The backend will just
+   * return the file as its needed, and with the proper format to be processed here
+   */
+  const handleMergeFiles = async () => {
+    let response = await mergeFiles(files);
+
+    if (response.error) {
+      toast.error(response.error);
+      return;
+    }
+
+    dispatch(setMergedFile(response.specification));
+
+    files.map((file) => sendFileToPreview(file));
+
+    return response.specification;
+  };
+
+  /**
+   * Be sure that the uploaded file contains only one domain to map to
+   */
+  const handleCheckDomainsInFile = async (spec) => {
+    let response = await checkDomainsInFile(spec);
+
+    if (response.error) {
+      toast.error(response.error);
+      return;
+    }
+
+    if (response.domains.length > 1) {
+      setMultipleDomainsInFile(true);
+      setDomainsInFile(response.domains);
+      return;
+    }
+  };
+
+  /**
+   * Manage to work with only 1 file with all the information.
+   */
+  const processFiles = async () => {
+    let spec = await handleMergeFiles();
+
+    await handleCheckDomainsInFile(spec);
+  };
+
+  /**
    * Send the file/s to the API service to be parsed
    */
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    // Check the form validity
     if (errors) {
       toast.error("Please correct the errors first");
       event.preventDefault();
       return;
     }
 
+    // Update the shared state
     dispatch(startProcessingFile());
     dispatch(setMappingFormData(formData()));
 
-    /**
-     * Be sure the file uploaded contains only one domain to map to
-     */
-    files.map(async (file) => {
-      let response = await checkDomainsInFile(file);
+    // Manage file tasks with the service
+    await processFiles();
 
-      if (response.error) {
-        toast.error(response.error);
-        return;
-      }
-
-      if (response.domains.length > 1) {
-        setMultipleDomainsInFile(true);
-        setDomainsInFile(response.domains);
-        return;
-      }
-
-      dispatch(stopProcessingFile());
-      sendFileToPreview(file);
-    });
-
+    // Update the shared state
+    dispatch(stopProcessingFile());
     dispatch(doSubmit());
-    event.preventDefault();
+  };
+
+  /**
+   * Filter the specification to have only those properties related to the
+   * selected domain.
+   *
+   * @param {String} id: The uri of the selected domain
+   */
+  const handleFilterSpecification = async (id) => {
+    let response = await filterSpecification(id, mergedFile);
+
+    if (response.error) {
+      toast.error(response.error);
+      return;
+    }
+
+    dispatch(setVocabularies(response.filtered.vocabularies));
+
+    return response.filtered.specification;
   };
 
   /**
@@ -183,22 +244,18 @@ const MappingForm = () => {
    * Then filter the file content to only show the selected domain an
    * related properties.
    */
-  const onSelectDomainFromFile = (id) => {
+  const onSelectDomainFromFile = async (id) => {
     dispatch(startProcessingFile());
     setMultipleDomainsInFile(false);
 
     let tempSpecs = [];
-    files.map((file) => {
-      filterSpecification(id, file).then((response) => {
-        if (response.error) {
-          toast.error(response.error);
-          return;
-        }
-        tempSpecs.push(JSON.stringify(response.specification, null, 2));
-        dispatch(setSpecToPreview(tempSpecs));
-        dispatch(stopProcessingFile());
-      });
-    });
+    let specification = await handleFilterSpecification(id);
+    dispatch(setMergedFile(specification));
+
+    tempSpecs.push(JSON.stringify(specification, null, 2));
+
+    dispatch(setSpecToPreview(tempSpecs));
+    dispatch(stopProcessingFile());
 
     toast.info("Great! You selected the domain with URI: " + id);
   };

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -9,6 +9,7 @@ import {
   startProcessingFile,
   stopProcessingFile,
   setMappingFormData,
+  doUnsubmit,
 } from "../../actions/mappingform";
 import fetchDomains from "../../services/fetchDomains";
 import { toastr as toast } from "react-redux-toastr";
@@ -65,6 +66,9 @@ const MappingForm = () => {
 
   /// Whether the form was submitted or not, in order to show the preview
   const submitted = useSelector((state) => state.submitted);
+
+  /// Whether we are processing the file or not
+  const processingFile = useSelector((state) => state.processingFile);
 
   const dispatch = useDispatch();
 
@@ -321,7 +325,7 @@ const MappingForm = () => {
 
       <div
         className={
-          (submitted ? "disabled-container " : " ") + "col-lg-6 p-lg-5 pt-5"
+          (submitted || processingFile ? "disabled-container " : " ") + "col-lg-6 p-lg-5 pt-5"
         }
       >
         {errors && <AlertNotice message={errors} />}

--- a/app/javascript/components/mapping/MappingPreview.jsx
+++ b/app/javascript/components/mapping/MappingPreview.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { unsetFiles, unsetSpecToPreview } from "../../actions/files";
+import { unsetFiles, unsetMergedFile, unsetSpecToPreview } from "../../actions/files";
 import FileContent from "./FileContent";
 import { doUnsubmit, startProcessingFile, stopProcessingFile } from "../../actions/mappingform";
 import Loader from "./../shared/Loader";
@@ -12,6 +12,7 @@ const MappingPreview = (props) => {
   const submitted = useSelector((state) => state.submitted);
   const processingFile = useSelector((state) => state.processingFile);
   const previewSpecs = useSelector((state) => state.previewSpecs);
+  const mergedFile = useSelector((state) => state.mergedFile);
   const mappingFormData = useSelector((state) => state.mappingFormData);
   const [creatingSpec, setCreatingSpec] = useState(false);
   const dispatch = useDispatch();
@@ -27,6 +28,10 @@ const MappingPreview = (props) => {
     dispatch(unsetSpecToPreview());
     // Change the form status to unsubmitted
     dispatch(doUnsubmit());
+    // Remove unified file
+    dispatch(unsetMergedFile());
+    // Remove vocabularies
+    dispatch(unsetVocabularies());
     // Reset the file uploader
     $("#file-uploader").val("");
   };
@@ -37,7 +42,7 @@ const MappingPreview = (props) => {
   const createSpecification = () => {
     setCreatingSpec(true);
     /// Send the specifications to the backend
-    mappingFormData.specifications = previewSpecs;
+    mappingFormData.specification = mergedFile;
 
     createSpec(mappingFormData).then((response) => {
       setCreatingSpec(false);
@@ -82,7 +87,7 @@ const MappingPreview = (props) => {
         ) : (
           submitted && (
             <React.Fragment>
-              <div className="card">
+              <div className="card mb-5">
                 <div className="card-header">
                   <div className="row">
                     <div className="col-6 align-self-center">

--- a/app/javascript/components/mapping/MappingPreview.jsx
+++ b/app/javascript/components/mapping/MappingPreview.jsx
@@ -7,6 +7,7 @@ import Loader from "./../shared/Loader";
 import createSpec from "../../services/createSpec";
 import { toastr as toast } from "react-redux-toastr";
 import createMapping from "../../services/createMapping";
+import { unsetVocabularies } from "../../actions/vocabularies";
 
 const MappingPreview = (props) => {
   const submitted = useSelector((state) => state.submitted);

--- a/app/javascript/reducers/index.jsx
+++ b/app/javascript/reducers/index.jsx
@@ -1,25 +1,29 @@
 import loggedReducer from "./loggedReducer";
 import userReducer from "./userReducer";
 import fileReducer from "./fileReducer";
+import mergedFileReducer from "./mergedFileReducer";
 import submittedReducer from "./submittedReducer";
 import previewSpecReducer from "./previewSpecReducer";
 import { combineReducers } from "redux";
 import { reducer as toastrReducer } from "react-redux-toastr";
 import fileProcessingReducer from "./fileProcessingReducer";
 import mappingFormReducer from "./mappingFormReducer";
+import vocabulariesReducer from "./vocabulariesReducer";
 
 /**
  * Represents a single reducer that contains all the reducers.
  */
 const allReducers = combineReducers({
-  loggedIn: loggedReducer,
-  user: userReducer,
   files: fileReducer,
-  submitted: submittedReducer,
+  loggedIn: loggedReducer,
+  mappingFormData: mappingFormReducer,
+  mergedFile: mergedFileReducer,
   previewSpecs: previewSpecReducer,
   processingFile: fileProcessingReducer,
-  mappingFormData: mappingFormReducer,
+  submitted: submittedReducer,
   toastr: toastrReducer,
+  user: userReducer,
+  vocabularies: vocabulariesReducer,
 });
 
 export default allReducers;

--- a/app/javascript/reducers/mergedFileReducer.jsx
+++ b/app/javascript/reducers/mergedFileReducer.jsx
@@ -1,0 +1,21 @@
+/**
+ * Sets the unified file object to an empty object or a valid one
+ * depending on the action
+ * 
+ * This represents the file that's uploaded by the user on the "mapping form".
+ * If it's more than one, it gets merged
+ * 
+ * @returns {Array}
+ */
+const mergedFileReducer = (state = {}, action) => {
+  switch (action.type) {
+    case "SET_MERGED_FILE":
+      return action.payload;
+    case "UNSET_MERGED_FILE":
+      return {};
+    default:
+      return state;
+  }
+};
+
+export default mergedFileReducer;

--- a/app/javascript/reducers/vocabulariesReducer.jsx
+++ b/app/javascript/reducers/vocabulariesReducer.jsx
@@ -1,0 +1,22 @@
+/**
+ * Sets the vocabularies collection (on upload phase) to an empty array or a valid one
+ * depending on the action
+ * 
+ * These are the vocabularies found in the files selected by the user in the attachment
+ * input on the "mapping form", or in the further screens when uploading vocabularies
+ * for the specification.
+ * 
+ * @returns {Array}
+ */
+const vocabulariesReducer = (state = [], action) => {
+  switch (action.type) {
+    case "SET_VOCABULARIES":
+      return action.payload;
+    case "UNSET_VOCABULARIES":
+      return [];
+    default:
+      return state;
+  }
+};
+
+export default vocabulariesReducer;

--- a/app/javascript/services/checkDomainsInFile.jsx
+++ b/app/javascript/services/checkDomainsInFile.jsx
@@ -1,20 +1,15 @@
 import apiRequest from "./api/apiRequest";
 
 const checkDomainsInFile = async (file) => {
-  let data = new FormData();
-  data.append("file", file);
   /// Send the file to the api to analyze
   const response = await apiRequest({
     url: "/api/v1/specifications/info",
     method: "post",
-    payload: data,
+    payload: {
+      file: JSON.stringify(file, null, 2),
+    },
     deafultResponse: [],
     successResponse: "domains",
-    options: {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    },
   });
   return response;
 };

--- a/app/javascript/services/checkDomainsInFile.jsx
+++ b/app/javascript/services/checkDomainsInFile.jsx
@@ -6,9 +6,9 @@ const checkDomainsInFile = async (file) => {
     url: "/api/v1/specifications/info",
     method: "post",
     payload: {
-      file: JSON.stringify(file, null, 2),
+      file: JSON.stringify(file),
     },
-    deafultResponse: [],
+    defaultResponse: [],
     successResponse: "domains",
   });
   return response;

--- a/app/javascript/services/createSpec.js
+++ b/app/javascript/services/createSpec.js
@@ -5,12 +5,14 @@ const createSpec = async (data) => {
     url: "/api/v1/specifications",
     method: "post",
     payload: {
-      name: data.name,
-      version: data.version,
-      use_case: data.useCase,
-      domain_to: data.domainTo,
-      domain_from: data.domainFrom,
-      specifications: data.specifications,
+      specification: {
+        name: data.name,
+        version: data.version,
+        use_case: data.useCase,
+        domain_to: data.domainTo,
+        domain_from: data.domainFrom,
+        content: JSON.stringify(data.specification),
+      }
     },
   });
   return response;

--- a/app/javascript/services/filterSpecification.jsx
+++ b/app/javascript/services/filterSpecification.jsx
@@ -1,10 +1,9 @@
 import apiRequest from "./api/apiRequest";
-
+/**
+ * @param {String} uri: The identifier of the rdfs:Class selected.
+ * @param {file} file: The file to be filtered, in a JSON format.
+ */
 const filterSpecification = async (uri, file) => {
-  let data = new FormData();
-  data.append("file", file);
-  data.append("uri", uri);
-
   /**
    * This will be the way to get the specification file
    * parsed to get only 1 domain to map from.
@@ -19,14 +18,12 @@ const filterSpecification = async (uri, file) => {
   return await apiRequest({
     url: "/api/v1/specifications/filter",
     method: "post",
-    payload: data,
-    options: {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
+    payload: {
+      file: JSON.stringify(file, null, 2),
+      uri: uri,
     },
     defaultResponse: "",
-    successResponse: "specification",
+    successResponse: "filtered",
   });
 };
 

--- a/app/javascript/services/filterSpecification.jsx
+++ b/app/javascript/services/filterSpecification.jsx
@@ -19,7 +19,7 @@ const filterSpecification = async (uri, file) => {
     url: "/api/v1/specifications/filter",
     method: "post",
     payload: {
-      file: JSON.stringify(file, null, 2),
+      file: JSON.stringify(file),
       uri: uri,
     },
     defaultResponse: "",

--- a/app/javascript/services/mergeFiles.jsx
+++ b/app/javascript/services/mergeFiles.jsx
@@ -1,0 +1,24 @@
+import apiRequest from "./api/apiRequest";
+
+const mergeFiles = async (files) => {
+  /// Prepare the data
+  let data = new FormData();
+  files.forEach(file => data.append("files[]", file));
+
+  /// Send the files to the api to analyze
+  const response = await apiRequest({
+    url: "/api/v1/specifications/merge",
+    method: "post",
+    payload: data,
+    deafultResponse: [],
+    successResponse: "specification",
+    options: {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
+  });
+  return response;
+};
+
+export default mergeFiles;

--- a/app/models/specification.rb
+++ b/app/models/specification.rb
@@ -6,10 +6,22 @@
 #   form.
 ###
 class Specification < ApplicationRecord
+  ###
+  # @description: The user that created this specification
+  ###
   belongs_to :user
-  belongs_to :domain
-  has_many :terms, dependent: :destroy
 
+  ###
+  # @description: The class (domain) that this specification is representing
+  ###
+  belongs_to :domain
+
+  ###
+  # @description: The properties this specification has
+  ###
+  has_and_belongs_to_many :terms
+
+  after_create :mark_as_spine, unless: proc { domain.spine }
   before_create :assign_uri
   before_destroy :nullify_domain_spine
 
@@ -17,6 +29,14 @@ class Specification < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
 
   include Identifiable
+
+  ###
+  # @description: If there's no specification for the user's company and the selected domain
+  #   to map to, then it's the spine.
+  ###
+  def mark_as_spine
+    spine!
+  end
 
   ###
   # @description: Assigns the uri before saving into the database. The uri must be unique

--- a/app/models/specification.rb
+++ b/app/models/specification.rb
@@ -21,7 +21,11 @@ class Specification < ApplicationRecord
   ###
   has_and_belongs_to_many :terms
 
-  after_create :mark_as_spine, unless: proc { domain.spine }
+  ###
+  # @description: If there's no specification for the user's company and the selected domain
+  #   to map to, then it's the spine.
+  ###
+  after_create :spine!, unless: proc { domain.spine }
   before_create :assign_uri
   before_destroy :nullify_domain_spine
 
@@ -29,14 +33,6 @@ class Specification < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
 
   include Identifiable
-
-  ###
-  # @description: If there's no specification for the user's company and the selected domain
-  #   to map to, then it's the spine.
-  ###
-  def mark_as_spine
-    spine!
-  end
 
   ###
   # @description: Assigns the uri before saving into the database. The uri must be unique

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -4,12 +4,30 @@
 # @description: Represents a node of a specification
 ###
 class Term < ApplicationRecord
-  belongs_to :specification
+  ###
+  # @description: The specifications in which this term appears. Can be many
+  ###
+  has_and_belongs_to_many :specifications
+
+  ###
+  # @description: The property for this term, an entity that contains all the rdf property information
+  ###
   has_one :property, dependent: :destroy
+
+  ###
+  # @description: The skos concept scheme (vocabulary), for this term. It can be many, but in the most
+  #   common situations, each term will have 0 or 1 vocabulary
+  ###
   has_and_belongs_to_many :vocabularies
 
-  validates :uri, presence: true
+  ###
+  # @description: The uri for this term, it should be unique, even among different organizations
+  ###
+  validates :uri, presence: true, uniqueness: true
 
+  ###
+  # @description: Accept to update and/or create properties along with terms
+  ###
   accepts_nested_attributes_for :property, allow_destroy: true
 
   ###

--- a/app/services/parsers/format_converter.rb
+++ b/app/services/parsers/format_converter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Parsers
+  ###
+  # @description: This class is responsible for converting the specifications format to be json-ld
+  #   We support RFD, XML, JSON formats, but internally we only work with json-ld, so we need to
+  #   work with data in this format and this class will manage the conversion for us.
+  #
+  # @TODO this is a hook to integrate the conversion of file formats work. delete this comment when
+  #   the integration is completed
+  ###
+  class FormatConverter
+    ###
+    # @description:
+    # @param [ActionDispatch::Http::UploadedFile]: the file to be converted
+    # @return [Struct]
+    ###
+    def self.convert_to_jsonld file
+      File.read(file)
+    end
+  end
+end

--- a/app/services/processors/skos.rb
+++ b/app/services/processors/skos.rb
@@ -52,5 +52,26 @@ module Processors
         end
       end
     end
+
+    ###
+    # @description: Identify all the concepts for a given vocabulary id (scheme uri).
+    # @param [Array] graph: the collection of nodes. It can contain all kind of nodes, we will find only those with
+    #   type "skos:Concept" and related to the given scheme.
+    # @param [String] scheme_uri: The id of the scheme containing the concepts
+    # @return [Array]
+    ###
+    def self.identify_concepts graph, scheme_uri
+      concepts = []
+
+      graph.each do |node|
+        node_type = Parsers::Specifications.read!(node, "type")
+        if node_type.is_a?(String) && node_type.downcase == "skos:concept" &&
+           Parsers::Specifications.read!(node, "inScheme") == scheme_uri
+          concepts << node
+        end
+      end
+
+      concepts
+    end
   end
 end

--- a/app/services/processors/skos.rb
+++ b/app/services/processors/skos.rb
@@ -76,9 +76,9 @@ module Processors
     # @param [String] scheme_uri
     # @return [TrueClass|FalseClass]
     ###
-    def self.concept_of_scheme?(node, _scheme_uri)
+    def self.concept_of_scheme?(node, scheme_uri)
       concept_in_scheme = lambda {
-        return false if node["skos:inScheme"].present?
+        return false unless node["skos:inScheme"].present?
 
         return node["skos:inScheme"].any? {|s_uri| s_uri == scheme_uri } if node["skos:inScheme"].is_a?(Array)
 

--- a/app/services/processors/specifications.rb
+++ b/app/services/processors/specifications.rb
@@ -11,7 +11,7 @@ module Processors
     # @param [ActionDispatch::Http::UploadedFile] file The json file to be processed
     ###
     def self.process_domains_from_file(file)
-      # Make the file content available as a dpcjson object
+      # Make the file content available as a json object
       file_content = JSON.parse(file)
 
       # The domains are listed under the '@graph' object, because at this
@@ -68,7 +68,7 @@ module Processors
     ###
     def self.filter_specification(spec, uri)
       # Make the spec content available as a json object
-      spec = JSON.parse(spec) if spec.class.name == "String"
+      spec = JSON.parse(spec) if spec.is_a?(String)
 
       vocabularies = filter_vocabularies(spec)
       spec = filter_specification_by_domain_uri(spec, uri)
@@ -98,11 +98,12 @@ module Processors
         # Get all the concepts for this cocept scheme
         vocab = Processors::Skos.identify_concepts(spec["@graph"], Parsers::Specifications.read!(scheme_node, "id"))
 
-        # Place the cheme node at the beginning
+        # Place the scheme node at the beginning
         vocab.unshift(scheme_node)
 
         # Place the context at the beginning
-        vocab.unshift(spec["@context"])
+        # @todo: Modify the context to be only the elements needed by the vocabulary
+        # vocab.unshift(spec["@context"])
 
         # Add the voabulary to the list
         vocabs << vocab
@@ -143,7 +144,7 @@ module Processors
     #
     # @param [Array] nodes The collection of all the nodes to be processed to find
     #   the related ones
-    # @param [String] uri The id (URI) of the property to find related ones
+    # @param [String] uri The id (URI) of the class or property to find related ones
     ###
     def self.build_nodes_for_uri(nodes, uri)
       # Find all related properties

--- a/app/services/processors/specifications.rb
+++ b/app/services/processors/specifications.rb
@@ -89,27 +89,50 @@ module Processors
 
       # Get all the concept scheme nodes. With the pupose of separate all the vocabularies, we
       # need the concept schemes, which represents the vocabularies main nodes.
-      scheme_nodes = spec["@graph"].select {|node|
-        Parsers::Specifications.read!(node, "type").is_a?(String) &&
-        Parsers::Specifications.read!(node, "type").downcase == "skos:conceptscheme"
-      }
-
-      scheme_nodes.each do |scheme_node|
+      Processors::Skos.scheme_nodes_from_graph(spec["@graph"]).each do |scheme_node|
         # Get all the concepts for this cocept scheme
-        vocab = Processors::Skos.identify_concepts(spec["@graph"], Parsers::Specifications.read!(scheme_node, "id"))
+        vocab = {
+          "@graph": Processors::Skos.identify_concepts(spec["@graph"], Parsers::Specifications.read!(scheme_node, "id"))
+        }
 
         # Place the scheme node at the beginning
-        vocab.unshift(scheme_node)
+        vocab[:@graph].unshift(scheme_node)
 
         # Place the context at the beginning
-        # @todo: Modify the context to be only the elements needed by the vocabulary
-        # vocab.unshift(spec["@context"])
+        vocab[:@graph].unshift(vocab_context(vocab, spec["@context"]))
 
         # Add the voabulary to the list
         vocabs << vocab
       end
 
       vocabs
+    end
+
+    ###
+    # @description: From a wide context, generate a new one, containing only the keys that are needed for the
+    #   given vocabulary
+    # @param [Hash] vocab: The vocabulary to be analyzed
+    # @return [Hash] context: The wider context to be used as context source
+    ###
+    def self.vocab_context(vocab, context)
+      final_context = {}
+
+      # We only have concepts at this point, so accessing the graph is fine.
+      # Proceed to iterate through each concept in the graph
+      vocab[:@graph].each do |concept|
+        # Each concept will have different keys (here, the concepts are represented as hashes)
+        # We iterate through each key of the concept, wich represents each "attribute"
+        concept.keys.each do |attr_key|
+          # We are only interested in those keys that uses the uris from the main context
+          # If so, we add the key and value to our new context
+          if Processors::Skos.using_context_uri(context, attr_key)
+            k, v = context.find {|key, _value| key.include?(attr_key.split(":").first) }
+            final_context[k] = v
+          end
+        end
+      end
+
+      final_context
     end
 
     ###

--- a/app/services/processors/specifications.rb
+++ b/app/services/processors/specifications.rb
@@ -92,14 +92,15 @@ module Processors
       Processors::Skos.scheme_nodes_from_graph(spec["@graph"]).each do |scheme_node|
         # Get all the concepts for this cocept scheme
         vocab = {
+          "@context": nil,
           "@graph": Processors::Skos.identify_concepts(spec["@graph"], Parsers::Specifications.read!(scheme_node, "id"))
         }
 
+        # Place the context at the beginning
+        vocab[:@context] = vocab_context(vocab, spec["@context"])
+
         # Place the scheme node at the beginning
         vocab[:@graph].unshift(scheme_node)
-
-        # Place the context at the beginning
-        vocab[:@graph].unshift(vocab_context(vocab, spec["@context"]))
 
         # Add the voabulary to the list
         vocabs << vocab

--- a/concepts/desmAbstractClasses.json
+++ b/concepts/desmAbstractClasses.json
@@ -67,7 +67,7 @@
       "id": "http://desm.org/concepts/employment",
       "type": "skos:Concept",
       "prefLabel": {"en-us": "Employment"},
-      "definition": {"en-us": "The condition of a person having paid work"},
+      "definition": {"en-us": "The condition of a persin having paid work"},
       "inScheme": "http://desm.org/concepts/mappingClasses"
     },
     {
@@ -82,13 +82,6 @@
       "type": "skos:Concept",
       "prefLabel": {"en-us": "Program of Study"},
       "definition": {"en-us": "A program of study means any course or grouping of courses prerequisite to or indicative of a degree."},
-      "inScheme": "http://desm.org/concepts/mappingClasses"
-    },
-    {
-      "id": "http://desm.org/concepts/earnings",
-      "type": "skos:Concept",
-      "prefLabel": {"en-us": "Earnings"},
-      "definition": {"en-us": "Aggregate data on the earnings of persons."},
       "inScheme": "http://desm.org/concepts/mappingClasses"
     }
   ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       get 'mappings/:id/terms' => 'mappings#show_terms'
       post 'specifications/info' => 'specifications#info'
       post 'specifications/filter' => 'specifications#filter'
+      post 'specifications/merge' => 'specifications#merge'
       get 'specifications/:id/terms' => 'terms#from_specification'
       get 'mapping_terms/:id/vocabulary' => 'alignment_vocabularies#show'
     end

--- a/db/migrate/20201109130153_create_specifications_terms_join_table.rb
+++ b/db/migrate/20201109130153_create_specifications_terms_join_table.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CreateSpecificationsTermsJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :specifications, :terms do |t|
+      t.index %i[specification_id term_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20201109134708_remove_specification_reference_from_terms.rb
+++ b/db/migrate/20201109134708_remove_specification_reference_from_terms.rb
@@ -2,6 +2,6 @@
 
 class RemoveSpecificationReferenceFromTerms < ActiveRecord::Migration[6.0]
   def change
-    remove_column :terms, :specification_id
+    remove_column :terms, :specification_id, :bigint
   end
 end

--- a/db/migrate/20201109134708_remove_specification_reference_from_terms.rb
+++ b/db/migrate/20201109134708_remove_specification_reference_from_terms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSpecificationReferenceFromTerms < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :terms, :specification_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_02_131905) do
+ActiveRecord::Schema.define(version: 2020_11_09_134708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,13 +179,17 @@ ActiveRecord::Schema.define(version: 2020_11_02_131905) do
     t.index ["user_id"], name: "index_specifications_on_user_id"
   end
 
+  create_table "specifications_terms", id: false, force: :cascade do |t|
+    t.bigint "specification_id", null: false
+    t.bigint "term_id", null: false
+    t.index ["specification_id", "term_id"], name: "index_specifications_terms_on_specification_id_and_term_id", unique: true
+  end
+
   create_table "terms", force: :cascade do |t|
     t.string "name"
     t.string "uri", null: false
-    t.bigint "specification_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["specification_id"], name: "index_terms_on_specification_id"
   end
 
   create_table "terms_vocabularies", id: false, force: :cascade do |t|
@@ -234,6 +238,5 @@ ActiveRecord::Schema.define(version: 2020_11_02_131905) do
   add_foreign_key "properties", "terms"
   add_foreign_key "specifications", "domains"
   add_foreign_key "specifications", "users"
-  add_foreign_key "terms", "specifications"
   add_foreign_key "vocabularies", "organizations"
 end

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-redux": "^7.2.1",
     "react-redux-toastr": "^7.6.5",
     "react-router-dom": "^5.2.0",
+    "react-tabs": "^3.1.1",
     "redux": "^4.0.5",
     "styled-components": "^5.2.0",
     "turbolinks": "^5.2.0",

--- a/spec/factories/terms.rb
+++ b/spec/factories/terms.rb
@@ -6,6 +6,5 @@ FactoryBot.define do
   factory :term do
     name { Faker::App.name }
     uri { Faker::Lorem.sentence }
-    specification
   end
 end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -8,5 +8,5 @@ describe Term, type: :model do
   end
 
   it { should validate_presence_of(:uri) }
-  it { should belong_to(:specification) }
+  it { should have_and_belong_to_many(:specifications) }
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,6 +2215,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
@@ -6278,7 +6283,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6430,6 +6435,11 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-animations@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-animations/-/react-animations-1.0.0.tgz#d96222920dfeabec8984d9b2ef2c5a5aadb40f06"
+  integrity sha512-ePPpVgdKnNEXm+LP1ww5s3n0JzebBw9QdRfxRqogzeg1PDIn6kf0pmvgeTeVZQXXpGmHImkIeTiaQR1O6xjntA==
+
 react-codemirror2@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-7.2.1.tgz#38dab492fcbe5fb8ebf5630e5bb7922db8d3a10c"
@@ -6529,6 +6539,14 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-tabs@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.1.1.tgz#b363a239f76046bb2158875a1e5921b11064052f"
+  integrity sha512-HpySC29NN1BkzBAnOC+ajfzPbTaVZcSWzMSjk56uAhPC/rBGtli8lTysR4CfPAyEE/hfweIzagOIoJ7nu80yng==
+  dependencies:
+    clsx "^1.1.0"
+    prop-types "^15.5.0"
 
 react@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
# What was done?

### Refactor term - specifications relation architecture

The specifications and terms relationship was meant to be one-to-many. This is not correct,
we need to represent terms to be part of one or many specifications.
It changed now so we improve the data handling in DB, impacting performance positively.

### Merge vocabularies when uploading multiple files

When the user uploads multiple files, before identifying domains (rdfs:classes),
we use the service to merge the files into one big JSON-LD file.

### Separate vocabularies on filtering, before the preview

With the purpose of being able to show the vocabularies on further screens, separate the vocabularies
as collections when filtering.

### Show the separated vocabularies on tabs

Work with the separated vocabularies obtained form the filtering phase, to
show it on tabs on the preview.

### Prepare a hook to integrate the "conversion of formats" work

# Screenshots

### New "Pre-Upload Phase Diagram"
> The actions taken when the user uploads one or more files are explained in the diagram below:
> NOTE: The "OPTIONAL" section is a preview for the next work yet to be completed.

![image](https://user-images.githubusercontent.com/6996951/98831182-ff3e7e00-2419-11eb-9d9a-1193ce968510.png)
