### PR TITLE
Feature/create vocabularies on upload phase

### DIFF
--- a/app/controllers/api/v1/vocabularies_controller.rb
+++ b/app/controllers/api/v1/vocabularies_controller.rb
@@ -24,6 +24,18 @@ class Api::V1::VocabulariesController < ApplicationController
   end
 
   ###
+  # @description: returns the vocabulary with the json structure as it is. Without ids
+  #   nor internal representation data. This endpoint will give us a vocabulary with the
+  #   exact structure we need: A JSON object with a "@context" and a "@graph".
+  ###
+  def flat
+    render json: {
+      "@context": @instance.context,
+      "@graph": [@instance.content].concat(@instance.concepts.map(&:raw))
+    }
+  end
+
+  ###
   # @description: Creates a vocabulary
   ###
   def create

--- a/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
+++ b/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
@@ -688,7 +688,7 @@ const AlignAndFineTune = (props) => {
     <React.Fragment>
       <div className="wrapper">
         <TopNav centerContent={navCenterOptions} />
-        {errors.length ? <AlertNotice message={errors.join("\n")} /> : ""}
+        {errors.length ? <AlertNotice message={errors} /> : ""}
         <div className="container-fluid container-wrapper">
           <div className="row">
             {loading ? (

--- a/app/javascript/components/align-and-fine-tune/match-vocabulary/MatchVocabulary.jsx
+++ b/app/javascript/components/align-and-fine-tune/match-vocabulary/MatchVocabulary.jsx
@@ -424,7 +424,7 @@ export default class MatchVocabulary extends Component {
           </div>
           <div className="card-body">
             {/* Manage to show the errors, if any */}
-            {errors.length ? <AlertNotice message={errors.join("\n")} /> : ""}
+            {errors.length ? <AlertNotice message={errors} /> : ""}
 
             {loading ? (
               <Loader />

--- a/app/javascript/components/mapping-to-domains/EditTerm.jsx
+++ b/app/javascript/components/mapping-to-domains/EditTerm.jsx
@@ -12,6 +12,7 @@ import fetchVocabularies from "../../services/fetchVocabularies";
 import rawTerm from "./rawTerm";
 import AlertNotice from "../shared/AlertNotice";
 import ExpandableOptions from "../shared/ExpandableOptions";
+import createVocabulary from "../../services/createVocabulary";
 
 export default class EditTerm extends Component {
   /**
@@ -64,8 +65,8 @@ export default class EditTerm extends Component {
 
   /**
    * Returns the currently selected domain for a term
-   * 
-   * @param {Array|String} domains 
+   *
+   * @param {Array|String} domains
    */
   setSelectedDomain = (domains) => {
     if (!_.isArray(domains)) {
@@ -77,8 +78,8 @@ export default class EditTerm extends Component {
 
   /**
    * Returns the currently selected range for a term
-   * 
-   * @param {Array|String} range 
+   *
+   * @param {Array|String} range
    */
   setSelectedRange = (range) => {
     if (!_.isArray(range)) {
@@ -185,19 +186,27 @@ export default class EditTerm extends Component {
    *
    * @param {Object} vocab
    */
-  handleVocabularyAdded = (vocab) => {
-    let tempTerm = this.state.term;
-    /// Add new vocabulary to the list of available ones
-    this.state.vocabularies.push({
-      id: vocab.id,
-      name: vocab.name,
+  handleVocabularyAdded = (data) => {
+    createVocabulary(data).then((response) => {
+      if (response.error) {
+        toast.error("Error! " + e.response.data.message);
+        return;
+      }
+      
+      let tempTerm = this.state.term;
+      /// Add new vocabulary to the list of available ones
+      this.state.vocabularies.push({
+        id: response.vocabulary.id,
+        name: response.vocabulary.name,
+      });
+      /// Add new vocabulary to the term selected vocabularies
+      tempTerm.vocabularies.push({
+        id: response.vocabulary.id,
+        name: response.vocabulary.name,
+      });
+
+      this.setState({ term: tempTerm });
     });
-    /// Add new vocabulary to the term selected vocabularies
-    tempTerm.vocabularies.push({
-      id: vocab.id,
-      name: vocab.name,
-    });
-    this.setState({ term: tempTerm });
   };
 
   /**
@@ -467,7 +476,6 @@ export default class EditTerm extends Component {
 
                     {this.state.uploadingVocabulary ? (
                       <UploadVocabulary
-                        term={this.state.term}
                         onVocabularyAdded={this.handleVocabularyAdded}
                         onRequestClose={() =>
                           this.setState({

--- a/app/javascript/components/mapping-to-domains/EditTerm.jsx
+++ b/app/javascript/components/mapping-to-domains/EditTerm.jsx
@@ -261,8 +261,8 @@ export default class EditTerm extends Component {
         onAfterOpen={this.fetchTermFromApi}
         contentLabel="Edit Term"
         style={{ ...ModalStyles }}
-        shouldCloseOnEsc={true}
-        shouldCloseOnOverlayClick={true}
+        shouldCloseOnEsc={false}
+        shouldCloseOnOverlayClick={false}
       >
         <div className="card ">
           <div className="card-header no-color-header">
@@ -284,7 +284,7 @@ export default class EditTerm extends Component {
             </div>
           </div>
 
-          <div className="card-body">
+          <div className="card-body scrollbar has-scrollbar">
             {this.state.error ? <AlertNotice message={this.state.error} /> : ""}
             {this.state.loading ? (
               <Loader />

--- a/app/javascript/components/mapping-to-domains/MappingToDomains.jsx
+++ b/app/javascript/components/mapping-to-domains/MappingToDomains.jsx
@@ -420,7 +420,7 @@ const MappingToDomains = (props) => {
       />
       <div className="wrapper">
         <TopNav centerContent={navCenterOptions} />
-        {errors.length ? <AlertNotice message={errors.join("\n")} /> : ""}
+        {errors.length ? <AlertNotice message={errors} /> : ""}
         <div className="container-fluid container-wrapper">
           <div className="row">
             {loading ? (

--- a/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
+++ b/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
@@ -154,7 +154,7 @@ const UploadVocabulary = (props) => {
       return;
     }
 
-    if(isValidJson(response.vocabulary)){
+    if (isValidJson(response.vocabulary)) {
       setFetchedVocabulary(response.vocabulary);
       handleSetFetchedVocabularyName(response.vocabulary);
     }
@@ -236,6 +236,122 @@ const UploadVocabulary = (props) => {
     }
   };
 
+  /**
+   * Structure of the form to upload a vocabulary from the filesystem
+   */
+  const FileUploadForm = () => {
+    return (
+      <div className="form-group">
+        <div className="input-group">
+          <div className="input-group-prepend">
+            <span className="input-group-text" id="upload-help">
+              Upload
+            </span>
+          </div>
+          <div className="custom-file">
+            <input
+              type="file"
+              className="file"
+              data-show-upload="true"
+              data-show-caption="true"
+              id="file-vocab-uploader"
+              aria-describedby="upload-help"
+              accept=".json, .jsonld"
+              onChange={handleFileChange}
+              required={true}
+            />
+            <label className="custom-file-label" htmlFor="file-vocab-uploader">
+              Attach File
+              <span className="text-danger">*</span>
+            </label>
+          </div>
+        </div>
+        <small className="mt-5">
+          You can upload your concept scheme file in JSONLD format (skos file)
+        </small>
+        <div className="row">
+          <div className="col">
+            <label
+              className="mt-3 mb-3 col-primary cursor-pointer float-right"
+              onClick={() => setUploadMode(uploadModes.FETCH_BY_URL)}
+            >
+              Fetch by URL
+            </label>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * Structure of the form to upload a vocabulary using an external URL
+   */
+  const URLUploadForm = () => {
+    return (
+      <div className="form-group">
+        <label htmlFor="vocabulary-url-input">Vocabulary URL</label>
+        <div className="row">
+          <div className="col-10">
+            <input
+              type="text"
+              className="form-control"
+              id="vocabulary-url-input"
+              name="vocabulary-url-input"
+              value={vocabularyURL}
+              onChange={(e) => setVocabularyURL(e.target.value)}
+              onBlur={handleVocabularyURLBlur}
+            />
+          </div>
+          <div className="col-2">
+            <a
+              className="btn btn-outline-secondary"
+              onClick={handleFetchVocabulary}
+              disabled={!vocabularyURL}
+            >
+              Fetch
+            </a>
+          </div>
+        </div>
+        <small className="form-text text-muted">It must be a valid URL</small>
+        <div className="row">
+          <div className="col">
+            <label
+              className="mt-3 mb-3 col-primary cursor-pointer float-right"
+              onClick={() => setUploadMode(uploadModes.FILE_UPLOAD)}
+            >
+              Upload a file from your system
+            </label>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * Returns a card with basic information about the recognized vocabulary
+   */
+  const FetchedVocabularyPreview = () => {
+    return (
+      <div className="row">
+        <div className="col">
+          <div className="card">
+            <div className="card-header">
+              <div className="row">
+                <div className="col-6">{fetchedVocabularyName}</div>
+                <div className="col-6">
+                  {handleFetchedVocabularyCantConcepts() + " concepts found"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * Render
+   */
   return (
     <Fragment>
       {errors.length ? <AlertNotice message={errors} /> : ""}
@@ -275,110 +391,15 @@ const UploadVocabulary = (props) => {
               />
             </div>
             {uploadMode == uploadModes.FILE_UPLOAD ? (
-              <div className="form-group">
-                <div className="input-group">
-                  <div className="input-group-prepend">
-                    <span className="input-group-text" id="upload-help">
-                      Upload
-                    </span>
-                  </div>
-                  <div className="custom-file">
-                    <input
-                      type="file"
-                      className="file"
-                      data-show-upload="true"
-                      data-show-caption="true"
-                      id="file-vocab-uploader"
-                      aria-describedby="upload-help"
-                      accept=".json, .jsonld"
-                      onChange={handleFileChange}
-                      required={true}
-                    />
-                    <label
-                      className="custom-file-label"
-                      htmlFor="file-vocab-uploader"
-                    >
-                      Attach File
-                      <span className="text-danger">*</span>
-                    </label>
-                  </div>
-                </div>
-                <small className="mt-5">
-                  You can upload your concept scheme file in JSONLD format (skos
-                  file)
-                </small>
-                <div className="row">
-                  <div className="col">
-                    <label
-                      className="mt-3 mb-3 col-primary cursor-pointer float-right"
-                      onClick={() => setUploadMode(uploadModes.FETCH_BY_URL)}
-                    >
-                      Fetch by URL
-                    </label>
-                  </div>
-                </div>
-              </div>
+              <FileUploadForm />
             ) : (
-              <div className="form-group">
-                <label htmlFor="vocabulary-url-input">Vocabulary URL</label>
-                <div className="row">
-                  <div className="col-10">
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="vocabulary-url-input"
-                      name="vocabulary-url-input"
-                      value={vocabularyURL}
-                      onChange={(e) => setVocabularyURL(e.target.value)}
-                      onBlur={handleVocabularyURLBlur}
-                    />
-                  </div>
-                  <div className="col-2">
-                    <a
-                      className="btn btn-outline-secondary"
-                      onClick={handleFetchVocabulary}
-                      disabled={!vocabularyURL}
-                    >
-                      Fetch
-                    </a>
-                  </div>
-                </div>
-                <small className="form-text text-muted">
-                  It must be a valid URL
-                </small>
-                <div className="row">
-                  <div className="col">
-                    <label
-                      className="mt-3 mb-3 col-primary cursor-pointer float-right"
-                      onClick={() => setUploadMode(uploadModes.FILE_UPLOAD)}
-                    >
-                      Upload a file from your system
-                    </label>
-                  </div>
-                </div>
-              </div>
+              <URLUploadForm />
             )}
 
             {uploadMode == uploadModes.FILE_UPLOAD && <FileData />}
 
             {uploadMode == uploadModes.FETCH_BY_URL &&
-              !_.isEmpty(fetchedVocabulary) && (
-                <div className="row">
-                  <div className="col">
-                    <div className="card">
-                      <div className="card-header">
-                        <div className="row">
-                          <div className="col-6">{fetchedVocabularyName}</div>
-                          <div className="col-6">
-                            {handleFetchedVocabularyCantConcepts() +
-                              " concepts found"}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
+              !_.isEmpty(fetchedVocabulary) && <FetchedVocabularyPreview />}
 
             <div className="row">
               <div className="col">

--- a/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
+++ b/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
@@ -7,11 +7,17 @@ var isJSON = require("is-valid-json");
 
 const UploadVocabulary = (props) => {
   /**
-   * The uploaded file whixh will contain the specification of
+   * The uploaded file which will contain the specification of
    * a vocabulary in a concept scheme json-ld format
    */
   const [file, setFile] = useState(null);
+  /**
+   * The content of the file. Set after reading it with a "FileReader"
+   */
   const [fileContent, setFileContent] = useState("");
+  /**
+   * Name for the vocabulary
+   */
   const [name, setName] = useState("");
 
   /**
@@ -38,7 +44,7 @@ const UploadVocabulary = (props) => {
    *
    * @returns {React.Fragment}
    */
-  const fileData = () => {
+  const FileData = () => {
     return file != null ? (
       <FileInfo selectedFile={file} key={Date.now() + file.lastModified} />
     ) : (
@@ -91,30 +97,18 @@ const UploadVocabulary = (props) => {
   /**
    * Send the file with the vocabulary to the backend
    */
-  const handleCreateVocabulary = (event) => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
     if (validateJSON(fileContent)) {
-      let data = {
+      props.onVocabularyAdded({
         vocabulary: {
           name: name,
           content: JSON.parse(fileContent),
-        }
-      };
-
-      createVocabulary(data).then((response) => {
-        if (response.error) {
-          toast.error("Error! " + e.response.data.message);
-          return;
-        }
-
-        props.onVocabularyAdded({
-          id: response.vocabulary.id,
-          name: response.vocabulary.name,
-        });
-
-        props.onRequestClose();
+        },
       });
 
-      event.preventDefault();
+      props.onRequestClose();
     }
   };
 
@@ -137,7 +131,7 @@ const UploadVocabulary = (props) => {
       </div>
 
       <div className="card-body">
-        <form onSubmit={handleCreateVocabulary}>
+        <form onSubmit={handleSubmit}>
           <div className="form-group">
             <label>
               Name
@@ -167,32 +161,35 @@ const UploadVocabulary = (props) => {
                   className="file"
                   data-show-upload="true"
                   data-show-caption="true"
-                  id="file-uploader"
+                  id="file-vocab-uploader"
                   aria-describedby="upload-help"
-                  // accept=".rdf, .json, .jsonld, .xml"
                   accept=".json, .jsonld"
                   onChange={handleFileChange}
                   required={true}
                 />
-                <label className="custom-file-label" htmlFor="file-uploader">
+                <label
+                  className="custom-file-label"
+                  htmlFor="file-vocab-uploader"
+                >
                   Attach File
                   <span className="text-danger">*</span>
                 </label>
               </div>
             </div>
             <small className="mt-5">
-              You can upload your concept scheme file as RDF, JSON, XML or
-              JSONLD format
+              You can upload your concept scheme file in JSONLD format (skos file)
             </small>
           </div>
 
-          {fileData()}
+          <FileData />
 
-          {file != null && (
-            <button className="btn btn-dark float-right mt-3" type="submit">
-              Upload
-            </button>
-          )}
+          <button
+            className="btn btn-dark float-right mt-3"
+            type="submit"
+            disabled={!file}
+          >
+            Upload
+          </button>
         </form>
       </div>
     </div>

--- a/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
+++ b/app/javascript/components/mapping-to-domains/UploadVocabulary.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import createVocabulary from "../../services/createVocabulary";
 import FileInfo from "../mapping/FileInfo";
 import { toastr as toast } from "react-redux-toastr";
+import { isValidVocabulary } from "../../helpers/Vocabularies";
 
 var isJSON = require("is-valid-json");
 
@@ -82,7 +82,7 @@ const UploadVocabulary = (props) => {
    *
    * @param {String} content
    */
-  const validateJSON = (content) => {
+  const isValidJson = (content) => {
     let isValid = isJSON(content);
 
     if (!isValid) {
@@ -95,12 +95,45 @@ const UploadVocabulary = (props) => {
   };
 
   /**
+   * Determines the vocabulary validity
+   *
+   * @param {Object} vocab
+   */
+  const vocabularyIsValid = (vocab) => {
+
+    let isValid = isValidVocabulary(vocab);
+
+    if (!isValid) {
+      toast.error(
+        "Invalid vocabulary!\
+        \nPlease check the vocabulary is a skos file with:\
+        \n- A context.\
+        \n- A graph.\
+        \n- A concept scheme node inside the graph.\
+        \n- At least one concept node inside the graph."
+      );
+    }
+
+    return isValid;
+  };
+
+  /**
+   * Perform file validation
+   *
+   * @param {String} vocab: Important! This needs to be string at this stage.
+   *   each task/layer will validate and transform if necessary.
+   */
+  const validateVocabulary = (vocab) => {
+    return isValidJson(vocab) && vocabularyIsValid(vocab);
+  };
+
+  /**
    * Send the file with the vocabulary to the backend
    */
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    if (validateJSON(fileContent)) {
+    if (validateVocabulary(fileContent)) {
       props.onVocabularyAdded({
         vocabulary: {
           name: name,
@@ -177,7 +210,8 @@ const UploadVocabulary = (props) => {
               </div>
             </div>
             <small className="mt-5">
-              You can upload your concept scheme file in JSONLD format (skos file)
+              You can upload your concept scheme file in JSONLD format (skos
+              file)
             </small>
           </div>
 

--- a/app/javascript/components/mapping/FileContent.jsx
+++ b/app/javascript/components/mapping/FileContent.jsx
@@ -1,24 +1,61 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import "react-tabs/style/react-tabs.css";
+import { setVocabularies } from "../../actions/vocabularies";
+import { vocabName } from "../../helpers/Vocabularies";
 
 /**
  * Reads the file content
+ *
+ * Props:
+ *
+ * @param {Boolean} disabled
  */
-const FileContent = () => {
+const FileContent = (props) => {
+  /**
+   * Elements from props
+   */
+  const { disabled } = props;
+  /**
+   * The specifcation contents ready to preview. THese are not the files object, but its contents
+   * @todo: After the refactoring to merge the files to work with only one, this ahouls be only one file
+   *    content, not a collection
+   */
   const previewSpecs = useSelector((state) => state.previewSpecs);
+  /**
+   * The vocabularies content ready to be printed. JSON format.
+   */
   const vocabularies = useSelector((state) => state.vocabularies);
+  /**
+   * Redux statement to be able to change the store.
+   */
+  const dispatch = useDispatch();
+
+  /**
+   * Remove a specific vocabulary from the collection of recognized vocabularies
+   *
+   * @param {Integer} i: The Vicabulary index to find in the vocabularies collection
+   */
+  const handleRemoveVocabulary = (i) => {
+    /// Remove the vocabulary using its index in the collection
+    let tempVocabularies = vocabularies;
+    delete tempVocabularies[i];
+
+    /// Refresh the UI
+    dispatch(setVocabularies([]));
+    dispatch(setVocabularies(tempVocabularies));
+  };
 
   return (
     <React.Fragment>
-      <Tabs>
+      <Tabs className={"mt-3" + (disabled ? " disabled-container" : "")}>
         <TabList>
           {previewSpecs.map((content, i) => {
-            return <Tab key={i}>{"Spec"}</Tab>
+            return <Tab key={i}>{"Spec"}</Tab>;
           })}
           {vocabularies.map((content, i) => {
-            return <Tab key={i}>{"Vocab " + (i + 1)}</Tab>;
+            return <Tab key={i}>{vocabName(content["@graph"])}</Tab>;
           })}
         </TabList>
 
@@ -36,13 +73,30 @@ const FileContent = () => {
           );
         })}
 
-        {vocabularies.map((content, i) => {
+        {vocabularies.map((vocabulary, i) => {
           return (
             <TabPanel key={i}>
-              <div className="card mt-2 mb-2 has-scrollbar scrollbar">
-                <div className="card-body">
+              <div className="card mt-2 mb-2">
+                <div className="card-header">
+                  <button
+                    className="btn float-right"
+                    onClick={() => {
+                      handleRemoveVocabulary(i);
+                    }}
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="Remove this vocabulary"
+                    disabled={disabled}
+                  >
+                    <i
+                      className="fa fa-trash cursor-pointer"
+                      aria-hidden="true"
+                    ></i>
+                  </button>
+                </div>
+                <div className="card-body  has-scrollbar scrollbar">
                   <pre>
-                    <code>{JSON.stringify(content, null, 2)}</code>
+                    <code>{JSON.stringify(vocabulary, null, 2)}</code>
                   </pre>
                 </div>
               </div>

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -267,10 +267,8 @@ const MappingForm = () => {
   /**
    * File content to be displayed after
    * file upload is complete
-   *
-   * @returns {React.Fragment}
    */
-  const fileData = () => {
+  const FileData = () => {
     let fileCards = [];
 
     if (files.length > 0) {
@@ -462,8 +460,7 @@ const MappingForm = () => {
                 Import Specification
               </button>
             </section>
-
-            {fileData()}
+            <FileData />
           </form>
         </section>
       </div>

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import validator from "validator";
 import AlertNotice from "../shared/AlertNotice";
 import FileInfo from "./FileInfo";
 import { useSelector, useDispatch } from "react-redux";
@@ -18,6 +17,7 @@ import checkDomainsInFile from "../../services/checkDomainsInFile";
 import filterSpecification from "../../services/filterSpecification";
 import mergeFiles from "../../services/mergeFiles";
 import { setVocabularies } from "../../actions/vocabularies";
+import { validURL } from "../../helpers/URL";
 
 const MappingForm = () => {
   const [errors, setErrors] = useState("");
@@ -85,7 +85,7 @@ const MappingForm = () => {
    * out the "use case" input
    */
   const handleUseCaseBlur = () => {
-    if (!validator.isURL(useCase)) {
+    if (!validURL(useCase)) {
       setErrors("'Use case' must be a valid URL");
     } else {
       setErrors("");

--- a/app/javascript/components/mapping/MappingPreview.jsx
+++ b/app/javascript/components/mapping/MappingPreview.jsx
@@ -15,9 +15,10 @@ import Loader from "./../shared/Loader";
 import createSpec from "../../services/createSpec";
 import { toastr as toast } from "react-redux-toastr";
 import createMapping from "../../services/createMapping";
-import { unsetVocabularies } from "../../actions/vocabularies";
+import { setVocabularies, unsetVocabularies } from "../../actions/vocabularies";
 import createVocabulary from "../../services/createVocabulary";
 import { vocabName } from "../../helpers/Vocabularies";
+import UploadVocabulary from "../mapping-to-domains/UploadVocabulary";
 
 const MappingPreview = (props) => {
   /**
@@ -52,6 +53,10 @@ const MappingPreview = (props) => {
    * Flag to know whether we are creating the specification.
    */
   const [creatingSpec, setCreatingSpec] = useState(false);
+  /**
+   * Flag to know whether we are adding a new vocabulary.
+   */
+  const [addingVocabulary, setAddingVocabulary] = useState(false);
   /**
    * Flag to know whether we are crating the vocabularies.
    */
@@ -120,6 +125,22 @@ const MappingPreview = (props) => {
       return "";
     }
   };
+
+  /**
+   * Actions after the vocabulary was successfully added into the api service
+   *
+   * @param {Object} vocab
+   */
+  const handleVocabularyAdded = (data) => {
+    /// Manage the vocabularies in the store
+    let tempVocabs = vocabularies;
+
+    /// Add the new vocabulary
+    tempVocabs.push(data.vocabulary.content);
+
+    /// Refresh the UI
+    dispatch(setVocabularies([]));
+    dispatch(setVocabularies(tempVocabs));  };
 
   /**
    * Use the api service to create one only vocabulary.
@@ -235,10 +256,33 @@ const MappingPreview = (props) => {
                   </div>
                 </div>
               </div>
+              <div className="row mb-3">
+                <div className="col">
+                  <label
+                    className="col-primary cursor-pointer float-right"
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="Add a new vocabulary"
+                    onClick={() => setAddingVocabulary(true)}
+                  >
+                    Add Vocabulary
+                  </label>
+                </div>
+              </div>
+
+              {addingVocabulary ? (
+                <UploadVocabulary
+                  onVocabularyAdded={handleVocabularyAdded}
+                  onRequestClose={() => setAddingVocabulary(false)}
+                />
+              ) : (
+                ""
+              )}
+
               {creatingSpec ? (
                 <Loader message="We're processing the specification. Please wait ..." />
               ) : (
-                <FileContent />
+                <FileContent disabled={addingVocabulary}/>
               )}
             </React.Fragment>
           )

--- a/app/javascript/components/mapping/MappingPreview.jsx
+++ b/app/javascript/components/mapping/MappingPreview.jsx
@@ -1,21 +1,64 @@
 import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { unsetFiles, unsetMergedFile, unsetSpecToPreview } from "../../actions/files";
+import {
+  unsetFiles,
+  unsetMergedFile,
+  unsetSpecToPreview,
+} from "../../actions/files";
 import FileContent from "./FileContent";
-import { doUnsubmit, startProcessingFile, stopProcessingFile } from "../../actions/mappingform";
+import {
+  doUnsubmit,
+  startProcessingFile,
+  stopProcessingFile,
+} from "../../actions/mappingform";
 import Loader from "./../shared/Loader";
 import createSpec from "../../services/createSpec";
 import { toastr as toast } from "react-redux-toastr";
 import createMapping from "../../services/createMapping";
 import { unsetVocabularies } from "../../actions/vocabularies";
+import createVocabulary from "../../services/createVocabulary";
+import { vocabName } from "../../helpers/Vocabularies";
 
 const MappingPreview = (props) => {
+  /**
+   * Whether the form is submitted. This means all the fields are already filled, and the
+   * file/s are uploaded. We can proceed with preview.
+   */
   const submitted = useSelector((state) => state.submitted);
+  /**
+   * Whether we are processing the specification file. Used for filtering, seeking domains, and merging.
+   */
   const processingFile = useSelector((state) => state.processingFile);
+  /**
+   * The specifcation contents ready to preview. THese are not the files object, but its contents
+   * @todo: After the refactoring to merge the files to work with only one, this ahouls be only one file
+   *    content, not a collection
+   */
   const previewSpecs = useSelector((state) => state.previewSpecs);
+  /**
+   * The files content already merged. If its only one file, the same result.
+   */
   const mergedFile = useSelector((state) => state.mergedFile);
+  /**
+   * The data to send when submitting in order to create the specification, vocabularies, and mapping if
+   * necessary (if its the spine, no mapping will be created)
+   */
   const mappingFormData = useSelector((state) => state.mappingFormData);
+  /**
+   * The vocabularies content ready to be printed. JSON format.
+   */
+  const vocabularies = useSelector((state) => state.vocabularies);
+  /**
+   * Flag to know whether we are creating the specification.
+   */
   const [creatingSpec, setCreatingSpec] = useState(false);
+  /**
+   * Flag to know whether we are crating the vocabularies.
+   */
+  const [creatingVocabularies, setCreatingVocabularies] = useState(false);
+  /**
+   * Redux statement to be able to change the store.
+   */
   const dispatch = useDispatch();
 
   /**
@@ -38,45 +81,123 @@ const MappingPreview = (props) => {
   };
 
   /**
-   * Call the api to create a specification with the data in the store
+   * Create the specification using the api service
    */
-  const createSpecification = () => {
+  const handleCreateSpecification = async () => {
     setCreatingSpec(true);
+
     /// Send the specifications to the backend
     mappingFormData.specification = mergedFile;
+    let response = await createSpec(mappingFormData);
 
-    createSpec(mappingFormData).then((response) => {
-      setCreatingSpec(false);
-      dispatch(doUnsubmit());
-      dispatch(unsetSpecToPreview());
-      dispatch(unsetFiles());
+    setCreatingSpec(false);
 
+    /// Refresh store data
+    dispatch(doUnsubmit());
+    dispatch(unsetSpecToPreview());
+    dispatch(unsetFiles());
+
+    /// Manage errors
+    if (response.error) {
+      toast.error(response.error);
+      return;
+    }
+
+    return response;
+  };
+
+  /**
+   * Look for the vocabulary name, being the vocabulary an object conatining only
+   * a grapha and a context.
+   *
+   * @param {Object} vocab
+   */
+  const handleLookForVocabularyName = (vocab) => {
+    try {
+      return vocabName(vocab["@graph"]);
+    } catch (error) {
+      toast.error(error);
+      return "";
+    }
+  };
+
+  /**
+   * Use the api service to create one only vocabulary.
+   *
+   * @param {String} name The name for the vocabulary
+   * @param {Object} content The JSON structured content for the vocabulary
+   */
+  const handleSaveOneVocabulary = async (name, content) => {
+    let response = await createVocabulary({
+      vocabulary: {
+        name: name,
+        content: content,
+      },
+    });
+
+    if (response.error) {
+      toast.error(response.error);
+      return false;
+    }
+
+    return true;
+  };
+
+  /**
+   * Create all the vocabularies
+   */
+  const handleCreateVocabularies = async () => {
+    let cantSaved = 0;
+
+    setCreatingVocabularies(true);
+    /// Iterate thorugh all the vocabularies, creating one by one using the api service
+    await Promise.all(
+      vocabularies.map(async (vocab) => {
+        /// Set the vocabulary name
+        let vName = handleLookForVocabularyName(vocab);
+
+        /// Do not continue if we didn't manage to get the vocabulary name, since this
+        /// will generate an error in the backend.
+        if (vName == "" || _.isUndefined(vName)) return;
+
+        if (await handleSaveOneVocabulary(vName, vocab)) {
+          cantSaved++;
+        }
+      })
+    );
+    setCreatingVocabularies(false);
+
+    if (cantSaved) toast.success(cantSaved + " vocabularies processed.");
+  };
+
+  /**
+   * Call the api to create a specification with the data in the store
+   */
+  const handleLooksGood = async () => {
+    let specResponse = await handleCreateSpecification();
+    await handleCreateVocabularies();
+
+    // if it's the spine, show a message to the user and return to home
+    if (specResponse["spine?"]) {
+      toast.success(
+        "You created a spine for this domain: " + specResponse.domain.uri
+      );
+      props.redirect("/");
+      return;
+    }
+
+    // If it's not the spine, the user is uploading a specification to map,
+    // so let's create the mapping and (with the id returned) load the
+    // mapping page
+    dispatch(startProcessingFile());
+    createMapping(specResponse.id).then((response) => {
       if (response.error) {
         toast.error(response.error);
         return;
       }
 
-      // if it's the spine, show a message to the user and return to home
-      if (response["spine?"]) {
-        toast.success(
-          "You created a spine for this domain: " + response.domain.uri
-        );
-        props.redirect("/");
-      } else {
-        // If it's not the spine, the user is uploading a specification to map,
-        // so let's create the mapping and (with the id returned) load the
-        // mapping page
-        dispatch(startProcessingFile());
-        createMapping(response.id).then((response) => {
-          if (response.error) {
-            toast.error(response.error);
-            return;
-          }
-
-          dispatch(stopProcessingFile());
-          props.redirect("/mappings/" + response.mapping.id);
-        });
-      }
+      dispatch(stopProcessingFile());
+      props.redirect("/mappings/" + response.mapping.id);
     });
   };
 
@@ -85,6 +206,8 @@ const MappingPreview = (props) => {
       <React.Fragment>
         {processingFile ? (
           <Loader message="We're processing the file. Please wait ..." />
+        ) : creatingVocabularies ? (
+          <Loader message="We're processing vocabularies. Please wait ..." />
         ) : (
           submitted && (
             <React.Fragment>
@@ -104,7 +227,7 @@ const MappingPreview = (props) => {
                       <button
                         className="btn bg-col-primary col-background ml-2"
                         disabled={creatingSpec || !previewSpecs.length}
-                        onClick={createSpecification}
+                        onClick={handleLooksGood}
                       >
                         Looks Good
                       </button>

--- a/app/javascript/components/shared/AlertNotice.jsx
+++ b/app/javascript/components/shared/AlertNotice.jsx
@@ -1,15 +1,51 @@
-import React from 'react';
+import React from "react";
 
+/**
+ * @description Renders an Alert box with a title and a message
+ *
+ * Props:
+ * @param {String} cssClass The class that will determine the color of the box. By default it's
+ *   "alert-danger", which will render a red box.
+ * @param {String} title The first and bolded word to remark. By default it's "Attention".
+ * @param {String|Array} message The message to show in the box. It can be both a string message
+ *   or an array of strings representing the multiple error messages
+ */
 const AlertNotice = (props) => {
+  /**
+   * Elements from props
+   */
+  const { cssClass, title, message } = props;
+
   return (
-    <div className={"alert alert-dismissible " + (props.cssClass ? props.cssClass : "alert-danger")}>
-      <h4><strong>{props.title ? props.title : "Attention!"}</strong></h4>
-      <p>{props.message}</p>
-      <button type="button" className="close" data-dismiss="alert" aria-label="Close">
+    <div
+      className={
+        "alert alert-dismissible " + (cssClass ? cssClass : "alert-danger")
+      }
+    >
+      <h4>
+        <strong>{title ? title : "Attention!"}</strong>
+      </h4>
+      {_.isArray(message) ? (
+        message.map((msg, i) => {
+          return (
+            <ul key={i}>
+              <li>{msg}</li>
+            </ul>
+          );
+        })
+      ) : (
+        <p>{message}</p>
+      )}
+      <button
+        type="button"
+        className="close"
+        data-dismiss="alert"
+        aria-label="Close"
+      >
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
-  )
-}
+  );
+};
 
 export default AlertNotice;

--- a/app/javascript/helpers/URL.js
+++ b/app/javascript/helpers/URL.js
@@ -1,0 +1,24 @@
+/**
+ * Returns whether a string correctly represents a valid URL
+ *
+ * @param {String} str
+ */
+export const validURL = (str) => {
+  var pattern = new RegExp(
+    /// protocol
+    "^(https?:\\/\\/)?" +
+      /// domain name
+      "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" +
+      /// OR ip (v4) address
+      "((\\d{1,3}\\.){3}\\d{1,3}))" +
+      /// port and path
+      "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" +
+      /// query string
+      "(\\?[;&a-z\\d%_.~+=-]*)?" +
+      /// fragment locator
+      "(\\#[-a-z\\d_]*)?$",
+    "i"
+  );
+
+  return pattern.test(str);
+};

--- a/app/javascript/helpers/Vocabularies.js
+++ b/app/javascript/helpers/Vocabularies.js
@@ -4,20 +4,15 @@
  * @param {Array} graph a list of nodes.
  */
 export const vocabName = (graph) => {
-  let schemeNode = graph.find((node) => {
-    let typeAttribute = node["type"] || node["@type"];
-    return typeAttribute.toLowerCase() === "skos:conceptscheme";
-  });
-
-  if (!schemeNode) {
-    throw "ConceptScheme node not found!"
-  }
-
-  let name = "";
+  let schemeNode = graphMainNode(graph);
 
   /// Look for an attribute with a name for the vocabulary in the concept scheme node
-  for(let attr in schemeNode) {
-    if(attr.toLowerCase().includes("title") || attr.toLowerCase().includes("label")){
+  let name = "";
+  for (let attr in schemeNode) {
+    if (
+      attr.toLowerCase().includes("title") ||
+      attr.toLowerCase().includes("label")
+    ) {
       name = readNodeAttribute(schemeNode, attr);
 
       break;
@@ -29,13 +24,13 @@ export const vocabName = (graph) => {
 
 /**
  * Safely read the skos concept attribute.
- * 
- * @param {Object} node 
- * @param {String} attr 
+ *
+ * @param {Object} node
+ * @param {String} attr
  */
 const readNodeAttribute = (node, attr) => {
   /// Return straight if it is a String
-  if (_.isString(node[attr])) return node[attr]
+  if (_.isString(node[attr])) return node[attr];
 
   /// We are reading an attribute that contains the words "title" or "label", but it's
   /// not a String. It contains one more level of nesting.  It can be the i18n management:
@@ -44,15 +39,32 @@ const readNodeAttribute = (node, attr) => {
   /// So our solution is to read the its attributes by using recursion, until one gives
   /// us a string.
   if (_.isObject(node[attr])) {
-    for(let a in node[attr]) {
+    for (let a in node[attr]) {
       return readNodeAttribute(node[attr], a);
     }
   }
 
   /// If it's an array, return the first element assuming it's a string. If it
   /// is not a string, just return an empty string.
-  if(_.isArray(node[attr])) {
+  if (_.isArray(node[attr])) {
     [firstNode] = node[attr];
     return _.isString(firstNode) ? firstNode : "";
   }
-}
+};
+
+/**
+ * Return the main node from a graph of a vocabulary (Returns the node of
+ * type "concept scheme").
+ *
+ * @param {Array} graph
+ */
+export const graphMainNode = (graph) => {
+  let schemeNode = graph.find((node) => {
+    let typeAttribute = node["type"] || node["@type"];
+    return typeAttribute.toLowerCase() === "skos:conceptscheme";
+  });
+
+  if (!schemeNode) throw "ConceptScheme node not found!";
+
+  return schemeNode;
+};

--- a/app/javascript/helpers/Vocabularies.js
+++ b/app/javascript/helpers/Vocabularies.js
@@ -1,0 +1,58 @@
+/**
+ * Generate a name for the vocabulary
+ *
+ * @param {Array} graph a list of nodes.
+ */
+export const vocabName = (graph) => {
+  let schemeNode = graph.find((node) => {
+    let typeAttribute = node["type"] || node["@type"];
+    return typeAttribute.toLowerCase() === "skos:conceptscheme";
+  });
+
+  if (!schemeNode) {
+    throw "ConceptScheme node not found!"
+  }
+
+  let name = "";
+
+  /// Look for an attribute with a name for the vocabulary in the concept scheme node
+  for(let attr in schemeNode) {
+    if(attr.toLowerCase().includes("title") || attr.toLowerCase().includes("label")){
+      name = readNodeAttribute(schemeNode, attr);
+
+      break;
+    }
+  }
+
+  return name;
+};
+
+/**
+ * Safely read the skos concept attribute.
+ * 
+ * @param {Object} node 
+ * @param {String} attr 
+ */
+const readNodeAttribute = (node, attr) => {
+  /// Return straight if it is a String
+  if (_.isString(node[attr])) return node[attr]
+
+  /// We are reading an attribute that contains the words "title" or "label", but it's
+  /// not a String. It contains one more level of nesting.  It can be the i18n management:
+  /// "en-US": "a description", or "en-us": "a description" (lowercased).
+  ///
+  /// So our solution is to read the its attributes by using recursion, until one gives
+  /// us a string.
+  if (_.isObject(node[attr])) {
+    for(let a in node[attr]) {
+      return readNodeAttribute(node[attr], a);
+    }
+  }
+
+  /// If it's an array, return the first element assuming it's a string. If it
+  /// is not a string, just return an empty string.
+  if(_.isArray(node[attr])) {
+    [firstNode] = node[attr];
+    return _.isString(firstNode) ? firstNode : "";
+  }
+}

--- a/app/javascript/helpers/Vocabularies.js
+++ b/app/javascript/helpers/Vocabularies.js
@@ -90,6 +90,8 @@ export const isValidVocabulary = (vocab) => {
   /// Ensure we deal with a JSON (object, not string)
   if (_.isString(vocab)) vocab = JSON.parse(vocab);
 
+  let errors = [];
+
   let hasContext = vocab["@context"];
   let hasGraph = vocab["@graph"];
   let hasMainNode = hasGraph && graphMainNode(vocab["@graph"]);
@@ -99,5 +101,13 @@ export const isValidVocabulary = (vocab) => {
       (node) => nodeType(node).toLowerCase() === "skos:concept"
     );
 
-  return hasContext && hasGraph && hasMainNode && hasConcepts;
+  if (!hasContext) errors.push("Missing context.");
+  if (!hasGraph) errors.push("Missing graph.");
+  if (!hasMainNode) errors.push("Missing concept scheme node.");
+  if (!hasConcepts) errors.push("Missing concept nodes");
+
+  return {
+    errors: errors,
+    result: hasContext && hasGraph && hasMainNode && hasConcepts,
+  };
 };

--- a/app/javascript/services/fetchExternalVocabulary.jsx
+++ b/app/javascript/services/fetchExternalVocabulary.jsx
@@ -1,0 +1,12 @@
+import apiRequest from "./api/apiRequest";
+
+const fetchExternalVocabulary = async (vocabularyURL) => {
+  return await apiRequest({
+    url: vocabularyURL,
+    method: "get",
+    defaultResponse: {},
+    successResponse: "vocabulary"
+  });
+};
+
+export default fetchExternalVocabulary;

--- a/app/policies/vocabulary_policy.rb
+++ b/app/policies/vocabulary_policy.rb
@@ -37,4 +37,12 @@ class VocabularyPolicy < ApplicationPolicy
   def show?
     @user.present?
   end
+
+  ###
+  # @description: Determines if the user can see this resource
+  # @return [TrueClass]
+  ###
+  def flat?
+    @user.present?
+  end
 end

--- a/app/services/processors/skos.rb
+++ b/app/services/processors/skos.rb
@@ -38,7 +38,8 @@ module Processors
       @vocabulary = Vocabulary.find_or_initialize_by(name: data[:attrs][:name]) do |vocab|
         vocab.update(
           organization: data[:organization],
-          content: data[:attrs][:content]["@graph"].select {|concept|
+          context: data[:attrs][:content]["@context"],
+          content: data[:attrs][:content]["@graph"].find {|concept|
             Parsers::Specifications.read!(concept, "type").downcase == "skos:conceptscheme"
           }
         )

--- a/app/services/processors/skos.rb
+++ b/app/services/processors/skos.rb
@@ -18,7 +18,9 @@ module Processors
         @vocabulary = create_vocabulary(data)
 
         @vocabulary.concepts = create_concepts(
-          data[:attrs][:content]["@graph"].select {|concept| concept["type"].downcase == "skos:concept" }
+          data[:attrs][:content]["@graph"].select {|concept|
+            Parsers::Specifications.read!(concept, "type").downcase == "skos:concept"
+          }
         )
       end
 
@@ -33,11 +35,14 @@ module Processors
     # @return {Vocabulary}: The created vocabulary
     ###
     def self.create_vocabulary data
-      @vocabulary = Vocabulary.create!(
-        name: data[:attrs][:name],
-        organization: data[:organization],
-        content: data[:attrs][:content]["@graph"].select {|concept| concept["type"].downcase == "skos:conceptscheme" }
-      )
+      @vocabulary = Vocabulary.find_or_initialize_by(name: data[:attrs][:name]) do |vocab|
+        vocab.update(
+          organization: data[:organization],
+          content: data[:attrs][:content]["@graph"].select {|concept|
+            Parsers::Specifications.read!(concept, "type").downcase == "skos:conceptscheme"
+          }
+        )
+      end
     end
 
     ###

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       post 'specifications/merge' => 'specifications#merge'
       get 'specifications/:id/terms' => 'terms#from_specification'
       get 'mapping_terms/:id/vocabulary' => 'alignment_vocabularies#show'
+      get 'vocabularies/:id/flat' => 'vocabularies#flat'
     end
   end
 

--- a/db/migrate/20201116120852_add_context_to_vocabulary.rb
+++ b/db/migrate/20201116120852_add_context_to_vocabulary.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddContextToVocabulary < ActiveRecord::Migration[6.0]
+  def change
+    change_table :vocabularies do |t|
+      t.jsonb :context, null: false, default: {}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_09_134708) do
+ActiveRecord::Schema.define(version: 2020_11_16_120852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 2020_11_09_134708) do
     t.jsonb "content", default: "{}", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "context", default: {}, null: false
     t.index ["organization_id"], name: "index_vocabularies_on_organization_id"
   end
 


### PR DESCRIPTION
# What was done?

### Create the vocabularies when creating the specification

Once the user clicks on "Looks Good", we use to just create the specification.
Now we also create the vocabularies recognized when parsing the file/s.
We create the vocabularies with the care of assigning the proper name reading it
safely by relying on a helper for that.

### Upload vocabulary on "upload phase"

When the user is uploading the specification, now we also recognize
vocabularies inside the uploaded file/s.
Now, we added a new option to let the user upload a new vocabulary, by
uploading a new file.

### Validate the "skos" file before uploading

When the user clicks "Upload" after selecting the vocabulary file,
validate that the file contains:
- A context.
- A graph.
- A concept scheme node inside the graph.
- At least one concept node inside the graph.
And return specific error messages for each one of those errors.

### Allow uploading a vocabulary from a URL

Inside the "upload vocabulary" component, let the user pick between:
uploading a file from the filesystem and
uploading a vocabulary using a URL

# Screenshots

### Adding a Vocabulary by URL

![add-by-url](https://user-images.githubusercontent.com/6996951/99296879-351ea080-2826-11eb-99d1-0645fe4c3642.gif)

### New Pre-Upload Phase Diagram

![new-upload-phase](https://user-images.githubusercontent.com/6996951/99297896-a9a60f00-2827-11eb-8ff4-a92323a92f37.png)
