### PR TITLE
Improvement/refactor file ingest

### DIFF
--- a/app/controllers/api/v1/specifications_controller.rb
+++ b/app/controllers/api/v1/specifications_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::SpecificationsController < ApplicationController
   #  related properties
   ###
   def filter
-    render json: Processors::Specifications.filter_specification(params[:file], params[:uri])
+    render json: Processors::Specifications.filter_specification(params[:file], params[:uris])
   end
 
   ###

--- a/app/controllers/api/v1/terms_controller.rb
+++ b/app/controllers/api/v1/terms_controller.rb
@@ -57,7 +57,7 @@ class Api::V1::TermsController < ApplicationController
     params.require(:term).permit(
       :name, :uri, :specification_id, {vocabulary_ids: []},
       property_attributes: [
-        :source_uri, :uri, :subproperty_of, :value_space, :label, :comment,
+        :id, :source_uri, :uri, :subproperty_of, :value_space, :label, :comment,
         {range: []}, :path, {domain: []}, :selected_domain, :selected_range
       ]
     )

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -226,10 +226,10 @@ const MappingForm = () => {
    * Filter the specification to have only those properties related to the
    * selected domain.
    *
-   * @param {String} id: The uri of the selected domain
+   * @param {Array} uris: The uri's of the selected domains
    */
-  const handleFilterSpecification = async (id) => {
-    let response = await filterSpecification(id, mergedFile);
+  const handleFilterSpecification = async (uris) => {
+    let response = await filterSpecification(uris, mergedFile);
 
     if (response.error) {
       toast.error(response.error);
@@ -247,13 +247,15 @@ const MappingForm = () => {
    *
    * Then filter the file content to only show the selected domain an
    * related properties.
+   *
+   * @param {Array} uris The list of identifiers of the rdfs:Class'es selected.
    */
-  const onSelectDomainFromFile = async (id) => {
+  const onSelectDomainsFromFile = async (uris) => {
     dispatch(startProcessingFile());
     setMultipleDomainsInFile(false);
 
     let tempSpecs = [];
-    let specification = await handleFilterSpecification(id);
+    let specification = await handleFilterSpecification(uris);
     dispatch(setMergedFile(specification));
 
     tempSpecs.push(JSON.stringify(specification, null, 2));
@@ -261,7 +263,10 @@ const MappingForm = () => {
     dispatch(setSpecToPreview(tempSpecs));
     dispatch(stopProcessingFile());
 
-    toast.info("Great! You selected the domain with URI: " + id);
+    toast.info(
+      "Great! You selected the following domains: " +
+        uris.map((uri) => uri.toString()).join("\n")
+    );
   };
 
   /**
@@ -314,16 +319,18 @@ const MappingForm = () => {
   return (
     <React.Fragment>
       <MultipleDomainsModal
+        domains={filteredDomainsInFile}
+        inputValue={inputValue}
         modalIsOpen={multipleDomainsInFile}
         onRequestClose={unsetMultipleDomains}
-        domains={filteredDomainsInFile}
-        onSelectDomain={onSelectDomainFromFile}
-        filterOnChange={filterOnChange}
+        onSubmit={onSelectDomainsFromFile}
+        onFilterChange={filterOnChange}
       />
 
       <div
         className={
-          (submitted || processingFile ? "disabled-container " : " ") + "col-lg-6 p-lg-5 pt-5"
+          (submitted || processingFile ? "disabled-container " : " ") +
+          "col-lg-6 p-lg-5 pt-5"
         }
       >
         {errors && <AlertNotice message={errors} />}

--- a/app/javascript/components/mapping/MappingPreview.jsx
+++ b/app/javascript/components/mapping/MappingPreview.jsx
@@ -226,7 +226,7 @@ const MappingPreview = (props) => {
     <div className="col-lg-6 p-lg-5 pt-5 bg-col-secondary">
       <React.Fragment>
         {processingFile ? (
-          <Loader message="We're processing the file. Please wait ..." />
+          <Loader message="We're processing the file/s. Please wait ..." />
         ) : creatingVocabularies ? (
           <Loader message="We're processing vocabularies. Please wait ..." />
         ) : (

--- a/app/javascript/components/mapping/MultipleDomainsModal.jsx
+++ b/app/javascript/components/mapping/MultipleDomainsModal.jsx
@@ -1,72 +1,172 @@
-import React from "react";
+import React, { Component } from "react";
 import Modal from "react-modal";
-import ModalStyles from '../shared/ModalStyles';
+import ModalStyles from "../shared/ModalStyles";
 
-const MultipleDomainsModal = (props) => {
-  Modal.setAppElement("body");
+/**
+ * Props:
+ * @param {array} domains The collection of domains to display
+ * @param {String} inputValue The value entered by the user in the search bar
+ * @param {Boolean} modalIsOpen Whether to show or not the modal window
+ * @param {Function} onFilterChange The actions to perform when the filter input changes
+ * @param {Function} onRequestClose Actions to perform on closing
+ * @param {Function} onSubmit The actions to perform when the user submits the form with
+ *   the selected domains
+ */
+export default class MultipleDomainsModal extends Component {
+  /**
+   * Representation of the state of this component
+   */
+  state = {
+    /**
+     * The complete list of available domains.
+     */
+    domainsList: this.props.domains,
+  };
 
-  return (
-    <Modal
-      isOpen={props.modalIsOpen}
-      onRequestClose={props.onRequestClose}
-      contentLabel="Multiple Domains Found"
-      style={ModalStyles}
-      shouldCloseOnEsc={false}
-      shouldCloseOnOverlayClick={false}
-    >
-      <div className="card" style={{maxHeight: "45rem"}}>
-        <div className="card-header">
-          <div className="row">
-            <div className="col-10">
-              <h5 className="col-primary"><strong>{props.domains.length}</strong> domains found</h5>
+  /**
+   * The list of selected domains. The ones the user selects
+   */
+  selectedDomains = () =>
+    this.state.domainsList.filter((domain) => domain.selected);
+
+  /**
+   * Actions to execute when a domain is clicked
+   *
+   * @param {Integer} domId
+   */
+  handleDomainClick = (domId) => {
+    const { domainsList } = this.state;
+
+    let dom = domainsList.find((d) => d.id == domId);
+    dom.selected = !dom.selected;
+
+    this.setState({ domainsList: domainsList });
+  };
+
+  /**
+   * Actions to take when submitting the selection of the domains. We manage here to pass
+   * over the selected domain ids as an array.
+   */
+  handleSubmit = () => {
+    const { onSubmit } = this.props;
+
+    onSubmit(this.selectedDomains().map((domain) => domain.uri));
+  };
+
+  /**
+   * Tasks when mounting this component
+   */
+  componentDidMount() {
+    Modal.setAppElement("body");
+  }
+
+  /**
+   * Update the list of domains in the state
+   *
+   * @param {Array} prevProps
+   */
+  componentDidUpdate(prevProps) {
+    if (this.props.domains !== prevProps.domains) {
+      this.setState({ domainsList: this.props.domains });
+    }
+  }
+
+  render() {
+    /**
+     * Elements from props
+     */
+    const {
+      domains,
+      inputValue,
+      onFilterChange,
+      modalIsOpen,
+      onRequestClose,
+    } = this.props;
+
+    return (
+      <Modal
+        isOpen={modalIsOpen}
+        onRequestClose={onRequestClose}
+        contentLabel="Multiple Domains Found"
+        style={ModalStyles}
+        shouldCloseOnEsc={false}
+        shouldCloseOnOverlayClick={false}
+      >
+        <div className="card" style={{ maxHeight: "45rem" }}>
+          <div className="card-header">
+            <div className="row">
+              <div className="col-10">
+                <h5 className="col-primary">
+                  <strong>{domains.length}</strong> domains found
+                </h5>
+              </div>
+              <div className="col-2">
+                <a
+                  className="float-right cursor-pointer"
+                  onClick={onRequestClose}
+                >
+                  <i className="fa fa-times" aria-hidden="true"></i>
+                </a>
+              </div>
             </div>
-            <div className="col-2">
-              <a
-                className="float-right cursor-pointer"
-                onClick={props.onRequestClose}
-              >
-                <i className="fa fa-times" aria-hidden="true"></i>
-              </a>
+
+            <div className="row">
+              <div className="col-10">
+                <label>
+                  {this.selectedDomains().length + " domains selected"}
+                </label>
+              </div>
+              <div className="col-2">
+                <button
+                  className="btn btn-block btn-dark"
+                  onClick={() => this.handleSubmit()}
+                  disabled={!this.selectedDomains().length}
+                >
+                  Done Selection
+                </button>
+              </div>
             </div>
-          </div>
-          <div className="row">
-            <div className="col">
-              <strong>Please select a domain from the list to begin mapping</strong>
-              <div className="form-group has-search">
-                <span className="fa fa-search form-control-feedback"></span>
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder="Search by name"
-                  value={props.inputValue}
-                  onChange={props.filterOnChange}
-                  autoFocus
-                />
+
+            <div className="row">
+              <div className="col">
+                <strong>
+                  Please select one or more domains from the list to begin
+                  mapping
+                </strong>
+                <div className="form-group has-search">
+                  <span className="fa fa-search form-control-feedback"></span>
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Search by name"
+                    value={inputValue}
+                    onChange={onFilterChange}
+                    autoFocus
+                  />
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div className="card-body has-scrollbar scrollbar">
-          <div className="desm-radio">
-            {props.domains.map(function (dom) {
-              return (
-                <div className="desm-radio-primary" key={"radio-" + dom.id}>
-                  <input
-                    type="radio"
-                    name="domain-options"
-                    id={"radio-" + dom.id}
-                    onClick={() => props.onSelectDomain(dom.uri)}
-                  />
-                  <label htmlFor={"radio-" + dom.id}>{dom.label}</label>
-                </div>
-              );
-            })}
+          <div className="card-body has-scrollbar scrollbar">
+            <div className="desm-radio">
+              {domains.map((dom) => {
+                return (
+                  <div className="desm-radio-primary" key={"radio-" + dom.id}>
+                    <input
+                      type="checkbox"
+                      name="domain-options"
+                      id={"chk-" + dom.id}
+                      onClick={() => this.handleDomainClick(dom.id)}
+                    />
+                    <label htmlFor={"chk-" + dom.id}>{dom.label}</label>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
-      </div>
-    </Modal>
-  );
-};
-
-export default MultipleDomainsModal;
+      </Modal>
+    );
+  }
+}

--- a/app/javascript/services/fetchTerm.jsx
+++ b/app/javascript/services/fetchTerm.jsx
@@ -1,12 +1,15 @@
+import { camelizeKeys } from "humps";
 import apiRequest from "./api/apiRequest";
 
 const fetchTerm = async (termId) => {
-  return await apiRequest({
+  let response = await apiRequest({
     url: "/api/v1/terms/" + termId,
     method: "get",
     defaultResponse: {},
     successResponse: "term",
   });
+
+  return camelizeKeys(response);
 };
 
 export default fetchTerm;

--- a/app/javascript/services/filterSpecification.jsx
+++ b/app/javascript/services/filterSpecification.jsx
@@ -1,9 +1,9 @@
 import apiRequest from "./api/apiRequest";
 /**
- * @param {String} uri: The identifier of the rdfs:Class selected.
  * @param {file} file: The file to be filtered, in a JSON format.
+ * @param {Array} uri: The list of identifiers of the rdfs:Class'es selected.
  */
-const filterSpecification = async (uri, file) => {
+const filterSpecification = async (uris, file) => {
   /**
    * This will be the way to get the specification file
    * parsed to get only 1 domain to map from.
@@ -20,7 +20,7 @@ const filterSpecification = async (uri, file) => {
     method: "post",
     payload: {
       file: JSON.stringify(file),
-      uri: uri,
+      uris: uris,
     },
     defaultResponse: "",
     successResponse: "filtered",

--- a/app/javascript/services/updateTerm.jsx
+++ b/app/javascript/services/updateTerm.jsx
@@ -1,3 +1,4 @@
+import { decamelizeKeys } from "humps";
 import apiRequest from "./api/apiRequest";
 
 const updateTerm = async (term) => {
@@ -7,7 +8,7 @@ const updateTerm = async (term) => {
     payload: {
       term: {
         name: term.name,
-        property_attributes: term.property,
+        property_attributes: decamelizeKeys(term.property),
         vocabulary_ids: term.vocabularies.map((v) => v.id),
       },
     },


### PR DESCRIPTION
# What was done?

### Support reading files with a different structure

Prior file ingest logic:
- We expect a file to have a context and a graph
of nodes with different types.

Current file ingest logic:
- Now we can process files with or without those
keys. If a file does not contain a graph we review it to be the case of a
file with an array of nodes (an implicit graph).
- Now we also take care of the files without a context but, with the keys
inside the nodes being full URI's.

### Prepare the backend to accept a list of domains to filter a specification

In the current workflow, at the upload phase, we ask the user to select only one domain
to filter the file. Now we support (backend, UI is just partially adapted ATM) filtering
using multiple domains.

### Support selecting more than 1 domain at upload phase

When a user uploads a file with more than 1 class (rdf:Class), we previously
ask the user to pick only 1 domain. This is an inconvenience since some domains
are defined by more than 1 rdf:Class.

Now we ask the user to select 1 or more domains, letting him search, as previously,
and also showing the user the number of domains currently being selected. Then we
filter the file using those domains the user selected, and let the user review.

This leads us to the generation of a more complete file.
