### PR TITLE
Feature/remove specifications

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -190,6 +190,16 @@ a:hover {
                                   supported by Chrome, Edge, Opera and Firefox */
 }
 
+.fit-content-height {
+  min-height: "fit-content"
+}
+
+.centered-width {
+  margin-left: 25%;
+  margin-right: 25%;
+  margin-top: 10%;
+}
+
 /* Scrollbar */
 
 .has-scrollbar {

--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -28,6 +28,17 @@ class Api::V1::MappingsController < ApplicationController
   end
 
   ###
+  # @description: Removes a mapping from the database
+  ###
+  def destroy
+    @instance.destroy!
+
+    render json: {
+      success: true
+    }
+  end
+
+  ###
   # @description: Udates the attributes of a mapping
   ###
   def update

--- a/app/controllers/api/v1/specifications_controller.rb
+++ b/app/controllers/api/v1/specifications_controller.rb
@@ -4,6 +4,8 @@
 # @description: Place all the actions related to specifications
 ###
 class Api::V1::SpecificationsController < ApplicationController
+  before_action :with_instance
+
   ###
   # @description: Process a specification file to organiza and return
   #   the related information, like how many domains it contains
@@ -51,6 +53,17 @@ class Api::V1::SpecificationsController < ApplicationController
     @specification = Specification.find(params[:id])
 
     render json: @specification, include: %i[user domain]
+  end
+
+  ###
+  # @description: Delete the given specification from the database
+  ###
+  def destroy
+    @instance.destroy!
+
+    render json: {
+      success: true
+    }
   end
 
   private

--- a/app/javascript/components/shared/ConfirmDialog.jsx
+++ b/app/javascript/components/shared/ConfirmDialog.jsx
@@ -1,0 +1,73 @@
+import Modal from "react-modal";
+import React from "react";
+import { FadeIn, SlideInDown } from "./Animations.jsx";
+
+/**
+ * Props:
+ * @param {Function} onConfirm
+ * @param {Function} onRequestClose
+ * @param {Boolean} visible
+ */
+const ConfirmDialog = (props) => {
+  Modal.setAppElement("body");
+
+  /**
+   * Elements from props
+   */
+  const { visible, onRequestClose, onConfirm, children } = props;
+
+  return (
+    <Modal
+      isOpen={visible}
+      onRequestClose={onRequestClose}
+      contentLabel="Please Confirm"
+      className={"fit-content-height m-5"}
+      style={{ marginLeft: "50%", marginRight: "50%" }}
+      shouldCloseOnEsc={false}
+      shouldCloseOnOverlayClick={false}
+    >
+      <SlideInDown>
+        <div className="card centered-width" style={{ maxHeight: "45rem" }}>
+          <div className="card-header">
+            <div className="row">
+              <div className="col-10">
+                <h3 className="col-primary">Please Confirm</h3>
+              </div>
+              <div className="col-2">
+                <a
+                  className="float-right cursor-pointer"
+                  onClick={onRequestClose}
+                >
+                  <i className="fa fa-times" aria-hidden="true"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div className="card-body has-scrollbar scrollbar">
+            <div className="row">
+              <div className="col">{children}</div>
+            </div>
+            <div className="row">
+              <div className="col">
+                <button
+                  className="btn btn-dark float-right ml-3"
+                  onClick={onConfirm}
+                >
+                  Confirm
+                </button>
+                <button
+                  className="btn btn-dark float-right ml-3"
+                  onClick={onRequestClose}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </SlideInDown>
+    </Modal>
+  );
+};
+
+export default ConfirmDialog;

--- a/app/javascript/components/specifications-list/SpineSpecsList.jsx
+++ b/app/javascript/components/specifications-list/SpineSpecsList.jsx
@@ -1,6 +1,9 @@
 import React, { Fragment, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import deleteSpecification from "../../services/deleteSpecification";
 import fetchSpineSpecifications from "../../services/fetchSpineSpecifications";
+import { Link } from "react-router-dom";
+import { toastr as toast } from "react-redux-toastr";
+import ConfirmDialog from "../shared/ConfirmDialog";
 
 /**
  * @description A list of spine specifications from the user or all the users of the organization
@@ -16,26 +19,77 @@ const SpineSpecsList = (props) => {
   const { filter } = props;
 
   /**
-   * Error message to present on the UI
+   * Representation of an error on this page process
    */
-  const [error, setError] = useState("");
+  const [errors, setErrors] = useState([]);
+
+  /**
+   * Controls displaying the removal confirmation dialog
+   */
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  /**
+   * The identifier of the spine to be removed. Saved in state, because the id is in an iterator,
+   * and the clicked handles confirmation, and the confirmation is outside the iterator.
+   */
+  const [spineIdToRemove, setSpineIdToRemove] = useState(null);
+
   /**
    * The collection of spine specifications
    */
   const [spines, setSpines] = useState([]);
 
   /**
-   * Retrieve all the spine specification for this user or organization
+   * Handle showing the errors on screen, if any
+   *
+   * @param {HttpResponse} response
+   */
+  function anyError(response) {
+    if (response.error) {
+      let tempErrors = errors;
+      tempErrors.push(response.error);
+      setErrors([]);
+      setErrors(tempErrors);
+    }
+    /// It will return a truthy value (depending no the existence
+    /// of the errors on the response object)
+    return !_.isUndefined(response.error);
+  }
+
+  /**
+   * Prepare the data to remove the spine. Ask the user to confirm removal.
+   *
+   * @param {Integer} spineId
+   */
+  const handleConfirmRemove = (spineId) => {
+    setConfirmingRemove(true);
+    setSpineIdToRemove(spineId);
+  };
+
+  /**
+   * Send a request to delete the selected spine.
+   */
+  const handleRemoveSpine = async () => {
+    let response = await deleteSpecification(spineIdToRemove);
+
+    if (!anyError(response)) {
+      toast.success("Spine removed");
+
+      /// Update the UI
+      setSpines(spines.filter((spine) => spine.id != spineIdToRemove));
+      setConfirmingRemove(false);
+    }
+  };
+
+  /**
+   * Retrieve all the spine specification for this user or organization.
    */
   const handleFetchSpineSpecs = async () => {
     let response = await fetchSpineSpecifications(filter);
 
-    if (response.error) {
-      setError(response.error);
-      return;
+    if (!anyError(response)) {
+      setSpines(response.specifications);
     }
-
-    setSpines(response.specifications);
   };
 
   useEffect(() => {
@@ -44,7 +98,17 @@ const SpineSpecsList = (props) => {
 
   return (
     <Fragment>
-      {!_.isEmpty(error) && <AlertNotice message={error} />}
+      {errors.length ? <AlertNotice message={errors} /> : null}
+
+      <ConfirmDialog
+        onRequestClose={() => setConfirmingRemove(false)}
+        onConfirm={() => handleRemoveSpine()}
+        visible={confirmingRemove}
+      >
+        <h2 className="text-center">You are removing the spine</h2>
+        <h5 className="mt-3 text-center">Please confirm this action.</h5>
+      </ConfirmDialog>
+
       {spines.map((spine) => {
         return (
           <tr key={spine.id}>
@@ -63,6 +127,12 @@ const SpineSpecsList = (props) => {
               >
                 Edit
               </Link>
+              <button
+                onClick={() => handleConfirmRemove(spine.id)}
+                className="btn btn-sm btn-dark ml-2"
+              >
+                Remove
+              </button>
             </td>
           </tr>
         );

--- a/app/javascript/services/deleteMapping.jsx
+++ b/app/javascript/services/deleteMapping.jsx
@@ -1,0 +1,10 @@
+import apiRequest from "./api/apiRequest";
+
+const deleteMapping = async (mappingId) => {
+  return await apiRequest({
+    url: "/api/v1/mappings/" + mappingId,
+    method: "delete"
+  });
+};
+
+export default deleteMapping;

--- a/app/javascript/services/deleteSpecification.jsx
+++ b/app/javascript/services/deleteSpecification.jsx
@@ -1,0 +1,10 @@
+import apiRequest from "./api/apiRequest";
+
+const deleteSpecification = async (term_id) => {
+  return await apiRequest({
+    url: "/api/v1/specifications/" + term_id,
+    method: "delete"
+  });
+};
+
+export default deleteSpecification;

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -13,14 +13,33 @@ class Mapping < ApplicationRecord
   #   the 'audits' method
   ###
   audited
-
+  ###
+  # @description: The user that this mapping belongs to
+  ###
   belongs_to :user
-  belongs_to :specification
+  ###
+  # @description: The specification that was uploaded to create this mapping
+  ###
+  belongs_to :specification, dependent: :destroy
+  ###
+  # @description: The specification chosen to map to
+  ###
   belongs_to :spine, foreign_key: "spine_id", class_name: :Specification
+  ###
+  # @description: Each term that conforms the mapping. The terms of the mapping contains informatio
+  #   about the type of alignment (predicate), which term from the spine was mapped to which of the
+  #   original specification, and more.
+  ###
   has_many :terms, class_name: :MappingTerm, dependent: :destroy
+  ###
+  # @description: The selected terms from the original uploaded specification. The user can select one
+  #   ore more terms from it.
+  ###
   has_and_belongs_to_many :selected_terms, join_table: :mapping_selected_terms, class_name: :Term
+  ###
+  # @description: Validates the presence of a name for the mapping
+  ###
   validates :name, presence: true
-
   # The possible status of a mapping
   # 1. "uploaded" It means that there's a specification uploaded but not
   #    terms mapped

--- a/app/policies/mapping_policy.rb
+++ b/app/policies/mapping_policy.rb
@@ -66,6 +66,14 @@ class MappingPolicy < ApplicationPolicy
   end
 
   ###
+  # @description: Determines if the user can remove an instance of this resource
+  # @return [TrueClass]
+  ###
+  def destroy?
+    @user.present?
+  end
+
+  ###
   # @description: Determines if the user can update an instance of this resource
   # @return [TrueClass]
   ###

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :audits, only: [:index]
       resources :domains, only: [:index, :show]
-      resources :mappings, only: [:create, :show, :index, :update]
+      resources :mappings, only: [:create, :destroy, :show, :index, :update]
       resources :mapping_terms, only: [:index, :update]
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :predicates, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :predicates, only: [:index]
       resources :roles, only: [:index]
-      resources :specifications, only: [:create, :show]
+      resources :specifications, only: [:create, :destroy, :show]
       resources :spine_terms, only: [:create]
       resources :terms, only: [:show, :update, :destroy]
       resources :vocabularies, only: [:index, :create, :show]


### PR DESCRIPTION
# What was done?

### Permit to remove a mapping

- Removing a mapping means removing the mapping entity itself with all the information around the specification that's uploaded to create it.

### Add option to remove a spine specification

- Prepare an abstract component to act as a confirm modal window to let
the user to give confirmation before performing an important action
such as remove something.
- Use the ConfirmDialog component to put it before confirming remove
the spine.
- Do not allow to remove a spine specification if there's a mapping related.

# Screenshots
![remove-mapping](https://user-images.githubusercontent.com/6996951/100649775-b21b4100-3321-11eb-813d-c3109ab6a494.gif)
