### PR TITLE
Improvement/minor UI improvements

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -17,6 +17,17 @@
   }
 }
 
+.floating-spec-btn {
+  border-radius: 50% !important;
+  font-size: 1.1rem !important;
+  font-weight: bold !important;
+  padding: 2rem !important;
+  position: absolute;
+  right: -2.5rem;
+  top: 50%;
+  z-index: 5;
+}
+
 .react-codemirror2{
   height: 100%;
   max-height: 27rem;

--- a/app/controllers/api/v1/mapping_terms_controller.rb
+++ b/app/controllers/api/v1/mapping_terms_controller.rb
@@ -30,6 +30,17 @@ class Api::V1::MappingTermsController < ApplicationController
     render json: @instance, include: %i[mapped_terms]
   end
 
+  ###
+  # @description: Removes an alignment from our records
+  ###
+  def destroy
+    @instance.destroy!
+
+    render json: {
+      success: true
+    }
+  end
+
   private
 
   ###

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -39,6 +39,7 @@ class Api::V1::OrganizationsController < ApplicationController
   ###
   def update
     @instance.update(permitted_params)
+
     render json: @instance
   end
 
@@ -67,6 +68,6 @@ class Api::V1::OrganizationsController < ApplicationController
   # @return [ActionController::Parameters]
   ###
   def permitted_params
-    params.require(:organization).permit(:name)
+    params.require(:organization).permit(:name, :email)
   end
 end

--- a/app/controllers/api/v1/spine_terms_controller.rb
+++ b/app/controllers/api/v1/spine_terms_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::SpineTermsController < ApplicationController
         ]
       ],
       mapping_term: %i[
-        comment predicate_id mapping_id uri
+        comment predicate_id mapping_id uri synthetic
       ]
     )
   end

--- a/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
+++ b/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
@@ -15,6 +15,7 @@ import MappingTermsHeaders from "./MappingTermsHeader";
 import Pluralize from "pluralize";
 import fetchMappingTerms from "../../services/fetchMappingTerms";
 import updateMappingTerm from "../../services/updateMappingTerm";
+import deleteAlignment from "../../services/deleteAlignment";
 import { toastr as toast } from "react-redux-toastr";
 import createSpineTerm from "../../services/createSpineTerm";
 import Draggable from "../shared/Draggable";
@@ -22,76 +23,51 @@ import { DraggableItemTypes } from "../shared/DraggableItemTypes";
 import updateMapping from "../../services/updateMapping";
 import MappingChangeLog from "./mapping-changelog/MappingChangeLog";
 import fetchAudits from "../../services/fetchAudits";
+import ConfirmDialog from "../shared/ConfirmDialog";
 
 const AlignAndFineTune = (props) => {
-  /**
-   * Representation of an error on this page process
-   */
-  const [errors, setErrors] = useState([]);
-
-  /**
-   * Whether the page is loading results or not
-   */
-  const [loading, setLoading] = useState(true);
-
-  /**
-   * The logged in user
-   */
-  const user = useSelector((state) => state.user);
-
-  /**
-   * Declare and have an initial state for the mapping
-   */
-  const [mapping, setMapping] = useState({});
-
-  /**
-   * The terms of the mapping (The ones for the output, not visible here, but necessary
-   * to configure the relation between the predicate, spine term and selected terms
-   * from the specification)
-   */
-  const [mappingTerms, setMappingTerms] = useState([]);
-
-  /**
-   * The terms of the mapping (The selected ones from the uploaded specification)
-   */
-  const [mappingSelectedTerms, setMappingSelectedTerms] = useState([]);
-
-  /**
-   * The terms of the spine (The specification being mapped against)
-   */
-  const [spineTerms, setSpineTerms] = useState([]);
-
-  /**
-   * The predicates from DB. These will be used to match a mapping term to a spine
-   * term in a meaningful way. E.g. "Identicall", "Agregatted", ...
-   */
-  const [predicates, setPredicates] = useState([]);
-
-  /**
-   * Whether any change awas performed after the page loads
-   */
-  const [changesPerformed, setChangesPerformed] = useState(0);
-
   /**
    * Whether any change awas performed after the page loads
    */
   const [addingSynthetic, setAddingSynthetic] = useState(false);
-
   /**
-   * Whether to hide mapped mapping terms or not
+   * Whether any change awas performed after the page loads
    */
-  const [hideMappedSpineTerms, setHideMappedSpineTerms] = useState(false);
-
+  const [changesPerformed, setChangesPerformed] = useState(0);
   /**
-   * Whether to hide mapped spine terms or not
+   * Controls displaying the removal confirmation dialog
    */
-  const [hideMappedSelectedTerms, setHideMappedSelectedTerms] = useState(false);
-
+  const [confirmingRemoveAlignment, setConfirmingRemoveAlignment] = useState(
+    false
+  );
   /**
    * The date the mapping was marked as "mapped", which is "completed".
    */
   const [dateMapped, setDateMapped] = useState(null);
-
+  /**
+   * Representation of an error on this page process
+   */
+  const [errors, setErrors] = useState([]);
+  /**
+   * Whether to hide mapped spine terms or not
+   */
+  const [hideMappedSelectedTerms, setHideMappedSelectedTerms] = useState(false);
+  /**
+   * Whether to hide mapped mapping terms or not
+   */
+  const [hideMappedSpineTerms, setHideMappedSpineTerms] = useState(false);
+  /**
+   * Whether the page is loading results or not
+   */
+  const [loading, setLoading] = useState(true);
+  /**
+   * Declare and have an initial state for the mapping
+   */
+  const [mapping, setMapping] = useState({});
+  /**
+   * The terms of the mapping (The selected ones from the uploaded specification)
+   */
+  const [mappingSelectedTerms, setMappingSelectedTerms] = useState([]);
   /**
    * The value of the input that the user is typing in the search box
    * to filter the list of mapping terms
@@ -100,12 +76,38 @@ const AlignAndFineTune = (props) => {
     mappingSelectedTermsInputValue,
     setMappingSelectedTermsInputValue,
   ] = useState("");
-
+  /**
+   * The terms of the mapping (The ones for the output, not visible here, but necessary
+   * to configure the relation between the predicate, spine term and selected terms
+   * from the specification)
+   */
+  const [mappingTerms, setMappingTerms] = useState([]);
+  /**
+   * Represents the alignment that's going to be removed if the user confirms that action
+   */
+  const [mappingTermToRemove, setMappingTermToRemove] = useState(null);
+  /**
+   * The predicates from DB. These will be used to match a mapping term to a spine
+   * term in a meaningful way. E.g. "Identicall", "Agregatted", ...
+   */
+  const [predicates, setPredicates] = useState([]);
+  /**
+   * The terms of the spine (The specification being mapped against)
+   */
+  const [spineTerms, setSpineTerms] = useState([]);
   /**
    * The value of the input that the user is typing in the search box
    * to filter the list of spine terms
    */
   const [spineTermsInputValue, setSpineTermsInputValue] = useState("");
+  /**
+   * The logged in user
+   */
+  const user = useSelector((state) => state.user);
+
+  /**
+   * ---- FUNCTIONS ----
+   */
 
   /**
    * The selected mapping terms (the terms of the original specification, now
@@ -310,9 +312,39 @@ const AlignAndFineTune = (props) => {
   };
 
   /**
+   * Manages to use the API service to remove an alignment
+   */
+  const handleRemoveAlignment = async () => {
+    let response = await deleteAlignment(mappingTermToRemove.id);
+
+    if (!anyError(response)) {
+      /// Update the UI
+      setMappingTerms([
+        ...mappingTerms.filter((mt) => mt.id !== mappingTermToRemove.id),
+      ]);
+      setSpineTerms([
+        ...spineTerms.filter(
+          (sTerm) => sTerm.id !== mappingTermToRemove.spine_term_id
+        ),
+      ]);
+
+      /// Close the modal confirmation window
+      setConfirmingRemoveAlignment(false);
+
+      /// If this is the only change, it's not right to count it as a change to save, since it's already
+      /// performed against the service, so it does not represent a change to perform.
+      setChangesPerformed(changesPerformed - 1);
+
+      /// Communicate the operation result to the user
+      toast.success("Synthetic alignment successfully removed");
+    }
+  };
+
+  /**
    * Mark the term not mapped.
    *
-   * @param {Object} mappingTerm Also called "alignment", containing the information about the spine term, predicate and mapped terms
+   * @param {Object} mappingTerm Also called "alignment", containing the information about the spine term,
+   * predicate and mapped terms.
    * @param {Object} mappedTerm The mapped term that's going to be dettached from the mapping term
    */
   const handleRevertMapping = (mappingTerm, mappedTerm) => {
@@ -320,6 +352,17 @@ const AlignAndFineTune = (props) => {
     mappingTerm.mapped_terms = mappingTerm.mapped_terms.filter(
       (mTerm) => mTerm.id !== mappedTerm.id
     );
+
+    /// If there's no mapped terms after removing the selected one to remove (this was the last mapped
+    /// term, and we removed it)
+    if (!mappingTerm.mapped_terms.length) {
+      mappingTerm.predicate_id = null;
+      if (mappingTerm.synthetic) {
+        setMappingTermToRemove(mappingTerm);
+        setConfirmingRemoveAlignment(true);
+      }
+    }
+
     setChangesPerformed(changesPerformed + 1);
     setMappingTerms([...mappingTerms]);
   };
@@ -491,6 +534,7 @@ const AlignAndFineTune = (props) => {
           ).id,
           mappingId: mapping.id,
           mappedTerms: mTerm.mapped_terms.map((term) => term.id),
+          synthetic: true,
         },
         specification_id: mapping.spine_id,
         spineTerm: {
@@ -731,6 +775,19 @@ const AlignAndFineTune = (props) => {
               <Loader />
             ) : (
               <React.Fragment>
+                <ConfirmDialog
+                  onRequestClose={() => setConfirmingRemoveAlignment(false)}
+                  onConfirm={() => handleRemoveAlignment()}
+                  visible={confirmingRemoveAlignment}
+                >
+                  <h2 className="text-center">
+                    You are removing an alignment permanently.
+                  </h2>
+                  <h5 className="mt-3 text-center">
+                    Please confirm this action.
+                  </h5>
+                </ConfirmDialog>
+
                 {/* LEFT SIDE */}
                 <div className="col-lg-8 p-lg-5 pt-5">
                   <SpineHeader

--- a/app/javascript/components/align-and-fine-tune/SpineTermRow.jsx
+++ b/app/javascript/components/align-and-fine-tune/SpineTermRow.jsx
@@ -23,12 +23,13 @@ const SpineTermRow = (props) => {
    * The data passed in props
    */
   const {
-    term,
-    predicates,
-    spineOrigin,
-    origin,
     mappedTermsToSpineTerm,
+    origin,
     onRevertMapping,
+    predicates,
+    selectedMappingTerms,
+    spineOrigin,
+    term,
   } = props;
 
   /**
@@ -184,7 +185,21 @@ const SpineTermRow = (props) => {
   };
 
   /**
-   * MAnages the actions when a user clicks to open the match vocabulary
+   * @description Handles the reverting action, by both calling the callback in props and ensurin
+   * the local state is updated.
+   * 
+   * @param {Object} mTerm The mapped term that's going to be dettached from the alignment 
+   */
+  const handleRevertMapping = (mTerm) => {
+    onRevertMapping(mTerm);
+
+    if (!mappingTerm.mapped_terms.length) {
+      setPredicate(null);
+    }
+  };
+
+  /**
+   * Manages the actions when a user clicks to open the match vocabulary
    */
   const handleMatchVocabularyClick = (mappedTerm) => {
     setMappedTermMatching(mappedTerm);
@@ -224,9 +239,9 @@ const SpineTermRow = (props) => {
       )}
 
       {term.vocabularies?.length &&
-      props
-        .mappedTermsToSpineTerm(term)
-        .some((mTerm) => mTerm.vocabularies && mTerm.vocabularies.length) ? (
+      mappedTermsToSpineTerm(term).some(
+        (mTerm) => mTerm.vocabularies && mTerm.vocabularies.length
+      ) ? (
         <MatchVocabulary
           modalIsOpen={matchingVocab}
           onRequestClose={onRequestVocabsClose}
@@ -288,7 +303,7 @@ const SpineTermRow = (props) => {
         </div>
 
         <div className="col-4">
-          {props.mappedTermsToSpineTerm(term).map((term) => {
+          {mappedTermsToSpineTerm(term).map((term) => {
             return (
               <Collapsible
                 headerContent={
@@ -298,7 +313,7 @@ const SpineTermRow = (props) => {
                       data-toggle="tooltip"
                       data-placement="top"
                       title="Revert selecting this term"
-                      onClick={() => onRevertMapping(term)}
+                      onClick={() => handleRevertMapping(term)}
                     >
                       <i className="fas fa-times"></i>
                     </div>
@@ -328,9 +343,9 @@ const SpineTermRow = (props) => {
               />
             );
           })}
-          {!props.mappedTermsToSpineTerm(term).length && (
+          {!mappedTermsToSpineTerm(term).length && (
             <DropZone
-              selectedCount={props.selectedMappingTerms.length}
+              selectedCount={selectedMappingTerms.length}
               acceptedItemType={DraggableItemTypes.PROPERTIES_SET}
               droppedItem={{ id: term.id }}
             />

--- a/app/javascript/components/dashboard/organizations/CreateOrganization.jsx
+++ b/app/javascript/components/dashboard/organizations/CreateOrganization.jsx
@@ -10,8 +10,17 @@ export default class CreateOrganization extends Component {
    * going to be sent to the API service in order to create an organization
    */
   state = {
-    name: "",
+    /**
+     * Errors from this component's actions
+     */
     errors: "",
+    /**
+     * The representation of the organization in the state of this component
+     */
+    organization: {
+      name: "",
+      email: "",
+    },
   };
 
   /**
@@ -19,10 +28,11 @@ export default class CreateOrganization extends Component {
    * the result to be shown to the user
    */
   handleSubmit = async (event) => {
-    const { name } = this.state;
+    const { organization } = this.state;
+
     event.preventDefault();
 
-    let response = await createOrganization(name);
+    let response = await createOrganization(organization);
 
     if (response.error) {
       this.setState({
@@ -32,7 +42,7 @@ export default class CreateOrganization extends Component {
     }
 
     if (response.success) {
-      toast.success("Organization " + name + " was successfully created");
+      toast.success("Organization " + organization.name + " was successfully created");
       this.props.history.push("/dashboard/organizations");
       return;
     }
@@ -42,17 +52,27 @@ export default class CreateOrganization extends Component {
    * Update the component state on every change in the input control in the form
    */
   handleOnChange = (event) => {
+    const { organization } = this.state;
+
+    let org = organization;
+    org[event.target.name] = event.target.value;
+
     this.setState({
-      [event.target.name]: event.target.value,
+      organization: org,
     });
   };
 
   render() {
+    /**
+     * Elements from state
+     */
+    const { errors, organization } = this.state;
+
     return (
       <React.Fragment>
         <DashboardContainer>
           <div className="col-lg-6 mx-auto mt-5">
-            {this.state.errors && <AlertNotice message={this.state.errors} />}
+            {errors && <AlertNotice message={errors} />}
 
             <div className="card mt-5">
               <div className="card-header">
@@ -71,9 +91,25 @@ export default class CreateOrganization extends Component {
                       className="form-control"
                       name="name"
                       placeholder="Enter a name for this organization"
-                      value={this.state.name}
+                      value={organization.name}
                       onChange={this.handleOnChange}
                       autoFocus
+                      required
+                    />
+                  </div>
+
+                  <div className="form-group">
+                    <label>
+                      Email
+                      <span className="text-danger">*</span>
+                    </label>
+                    <input
+                      type="email"
+                      className="form-control"
+                      name="email"
+                      placeholder="Enter an email for the organization"
+                      value={organization.email}
+                      onChange={(e) => this.handleOnChange(e)}
                       required
                     />
                   </div>

--- a/app/javascript/components/dashboard/organizations/OrganizationsIndex.jsx
+++ b/app/javascript/components/dashboard/organizations/OrganizationsIndex.jsx
@@ -62,6 +62,7 @@ export default class OrganizationsIndex extends Component {
                   <thead>
                     <tr>
                       <th>Name</th>
+                      <th>Email</th>
                       <th>Actions</th>
                     </tr>
                   </thead>
@@ -70,6 +71,7 @@ export default class OrganizationsIndex extends Component {
                       return (
                         <tr key={organization.id}>
                           <td>{organization.name}</td>
+                          <td>{organization.email}</td>
                           <td>
                             <Link
                               to={"/dashboard/organizations/" + organization.id}

--- a/app/javascript/components/mapping/MappingForm.jsx
+++ b/app/javascript/components/mapping/MappingForm.jsx
@@ -85,7 +85,7 @@ const MappingForm = () => {
    * out the "use case" input
    */
   const handleUseCaseBlur = () => {
-    if (!validURL(useCase)) {
+    if (!_.isEmpty(useCase) && !validURL(useCase)){
       setErrors("'Use case' must be a valid URL");
     } else {
       setErrors("");
@@ -346,6 +346,20 @@ const MappingForm = () => {
 
           <form onSubmit={handleSubmit}>
             <div className="form-group">
+              {Boolean(files.length) && !submitted && !processingFile && (
+                <section>
+                  <button
+                    type="submit"
+                    className="btn bg-col-primary col-background with-shadow floating-spec-btn mt-3"
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="Import the specification"
+                    disabled={submitted}
+                  >
+                    <i className="fas fa-arrow-right col-background"></i>
+                  </button>
+                </section>
+              )}
               <label htmlFor="specification_name">
                 Name of your specification
               </label>
@@ -372,7 +386,6 @@ const MappingForm = () => {
                 className="form-control"
                 value={version}
                 onChange={(e) => setVersion(e.target.value)}
-                required
                 disabled={submitted}
               />
             </div>
@@ -458,15 +471,6 @@ const MappingForm = () => {
               </label>
             </div>
 
-            <section>
-              <button
-                type="submit"
-                className="btn btn-dark mt-3"
-                disabled={submitted}
-              >
-                Import Specification
-              </button>
-            </section>
             <FileData />
           </form>
         </section>

--- a/app/javascript/services/createOrganization.jsx
+++ b/app/javascript/services/createOrganization.jsx
@@ -1,14 +1,10 @@
 import apiRequest from "./api/apiRequest";
 
-const createOrganization = async (name) => {
+const createOrganization = async (data) => {
   const response = await apiRequest({
     url: "/api/v1/organizations",
     method:"post",
-    payload: {
-      organization: {
-        name: name,
-      },
-    }
+    payload: data
   });
   return response;
 };

--- a/app/javascript/services/deleteAlignment.jsx
+++ b/app/javascript/services/deleteAlignment.jsx
@@ -1,0 +1,10 @@
+import apiRequest from "./api/apiRequest";
+
+const deleteMapping = async (alignmentId) => {
+  return await apiRequest({
+    url: "/api/v1/mapping_terms/" + alignmentId,
+    method: "delete"
+  });
+};
+
+export default deleteMapping;

--- a/app/javascript/services/updateOrganization.jsx
+++ b/app/javascript/services/updateOrganization.jsx
@@ -1,14 +1,10 @@
 import apiRequest from "./api/apiRequest";
 
-const updateOrganization = async (organization_id, name) => {
+const updateOrganization = async (id, data) => {
   return await apiRequest({
-    url: "/api/v1/organizations/" + organization_id,
+    url: "/api/v1/organizations/" + id,
     method: "put",
-    payload: {
-      organization: {
-        name: name,
-      },
-    },
+    payload: data,
   });
 };
 

--- a/app/models/mapping_term.rb
+++ b/app/models/mapping_term.rb
@@ -41,7 +41,12 @@ class MappingTerm < ApplicationRecord
   ###
   has_one :vocabulary, class_name: :AlignmentVocabulary
 
+  ###
+  # @description: Validates the presence of a uri before creating
+  ###
   validates :uri, presence: true
+
+  before_destroy :remove_spine_term, if: :synthetic
 
   ###
   # @description: Associate the terms to this alignment. NOTE: This method will replace the previous
@@ -61,6 +66,13 @@ class MappingTerm < ApplicationRecord
   ###
   def origin
     mapping.origin
+  end
+
+  ###
+  # @description: Removes the related spine term
+  ###
+  def remove_spine_term
+    spine_term.destroy!
   end
 
   ###

--- a/app/policies/mapping_term_policy.rb
+++ b/app/policies/mapping_term_policy.rb
@@ -20,4 +20,12 @@ class MappingTermPolicy < ApplicationPolicy
   def update?
     @user.present?
   end
+
+  ###
+  # @description: Determines if the user can remove an instance of this resource
+  # @return [TrueClass]
+  ###
+  def destroy?
+    @user.present?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       resources :audits, only: [:index]
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
-      resources :mapping_terms, only: [:index, :update]
+      resources :mapping_terms, only: [:destroy, :index, :update]
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :predicates, only: [:index]
       resources :roles, only: [:index]

--- a/db/migrate/20201201122921_add_weight_to_predicates.rb
+++ b/db/migrate/20201201122921_add_weight_to_predicates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddWeightToPredicates < ActiveRecord::Migration[6.0]
   def change
     change_table :predicates do |t|

--- a/db/migrate/20201203175730_add_synthetic_column_to_mapping_term.rb
+++ b/db/migrate/20201203175730_add_synthetic_column_to_mapping_term.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSyntheticColumnToMappingTerm < ActiveRecord::Migration[6.0]
+  def change
+    change_table :mapping_terms do |t|
+      t.boolean :synthetic, null: false, default: false
+    end
+  end
+end

--- a/db/migrate/20201204173854_add_email_to_organizations.rb
+++ b/db/migrate/20201204173854_add_email_to_organizations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddEmailToOrganizations < ActiveRecord::Migration[6.0]
+  def change
+    # Add the column to the table
+    change_table :organizations do |t|
+      t.string :email
+    end
+
+    # Update the exissting records
+    Organization.all.each {|o|
+      o.update(email: "info@#{o.name.split(".").first.strip.downcase}.org")
+    }
+
+    # Add the constraint
+    change_column_null(:organizations, :email, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_122921) do
+ActiveRecord::Schema.define(version: 2020_12_04_173854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_122921) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "vocabulary_id"
+    t.boolean "synthetic", default: false, null: false
     t.index ["mapping_id"], name: "index_mapping_terms_on_mapping_id"
     t.index ["predicate_id"], name: "index_mapping_terms_on_predicate_id"
     t.index ["vocabulary_id"], name: "index_mapping_terms_on_vocabulary_id"
@@ -140,6 +141,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_122921) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "email", null: false
   end
 
   create_table "predicates", force: :cascade do |t|


### PR DESCRIPTION
# What was done?

### Implement removal of predicate when removing a term from being mapped
- Once a user removes the last mapped term in a mapping, remove also the predicate choice.
- Remove synthetic term and alignment when the user removes all mapped terms in AFV.

### Design a new import specification button
- With the purpose of being more self-explanatory to the user, the form submit
button with the text "Import Specification", now is not visible until there's
a file and appears as a circle button with no text at the bottom of the form.
It also contains a tooltip to guide the user on the action.

### Make Use Case and Version not required
In the upload mapping form, change 2 text inputs to not be required.
- Use Case
- Version

# Screeshots
![import-spec-new-btn](https://user-images.githubusercontent.com/6996951/101181459-aa161680-362b-11eb-9100-15dd3bc2a005.gif)
