### PR TITLE
Feature/implement sort options in property mappings list

### DIFF
--- a/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
+++ b/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
@@ -185,13 +185,15 @@ const AlignAndFineTune = (props) => {
   const mappedSelectedTerms = mappingSelectedTerms.filter(selectedTermIsMapped);
 
   /**
-   * Returns whether all the terms from the specification are already mapped
+   * Returns whether all the terms from the specification are already mapped.
+   * For a term to be correctly mapped, we ensure to detect the predicate for it.
    */
-  const allTermsMapped = mappingSelectedTerms.every((term) =>
-    mappingTerms.some((mTerm) =>
-      mTerm.mapped_terms.some((t) => t.id === term.id)
-    )
-  );
+  const allTermsMapped =
+    mappingSelectedTerms.every((term) =>
+      mappingTerms.some((mTerm) =>
+        mTerm.mapped_terms.some((t) => t.id === term.id)
+      )
+    ) && mappingTerms.every((mTerm) => mTerm.predicate_id);
 
   /**
    * Returns wether the term is already mapped to the spine. It can be 1 of 2 options:

--- a/app/javascript/components/align-and-fine-tune/MappingTermsHeader.jsx
+++ b/app/javascript/components/align-and-fine-tune/MappingTermsHeader.jsx
@@ -48,14 +48,14 @@ const MappingTermsHeaders = (props) => {
           <div className="custom-control custom-checkbox mb-3">
             <input
               type="checkbox"
-              className="custom-control-input desm-custom-control-input"
+              className="custom-control-input desm-custom-control-input cursor-pointer"
               id="hideMappingElems"
-              value={hideMappedSelectedTerms}
+              checked={hideMappedSelectedTerms}
               onChange={(e) =>
                 setHideMappedSelectedTerms(!hideMappedSelectedTerms)
               }
             />
-            <label className="custom-control-label" htmlFor="hideMappingElems">
+            <label className="custom-control-label cursor-pointer" htmlFor="hideMappingElems">
               Hide Mapped Elements
             </label>
           </div>

--- a/app/javascript/components/align-and-fine-tune/SpineHeader.jsx
+++ b/app/javascript/components/align-and-fine-tune/SpineHeader.jsx
@@ -44,12 +44,12 @@ const SpineHeader = (props) => {
           <div className="custom-control custom-checkbox mb-3">
             <input
               type="checkbox"
-              className="custom-control-input desm-custom-control-input"
+              className="custom-control-input desm-custom-control-input cursor-pointer"
               id="hideSpineElems"
-              value={hideMappedSpineTerms}
+              checked={hideMappedSpineTerms}
               onChange={() => setHideMappedSpineTerms(!hideMappedSpineTerms)}
             />
-            <label className="custom-control-label" htmlFor="hideSpineElems">
+            <label className="custom-control-label cursor-pointer" htmlFor="hideSpineElems">
               Hide Mapped Elements
             </label>
           </div>

--- a/app/javascript/components/mapping-to-domains/EditTerm.jsx
+++ b/app/javascript/components/mapping-to-domains/EditTerm.jsx
@@ -58,60 +58,10 @@ export default class EditTerm extends Component {
       ? domains.map((domain, i) => {
           return {
             id: i,
-            name: _.isString(domain)
-              ? domain
-              : readNodeAttribute(domain, "@id"),
+            name: readNodeAttribute(domain, "@id"),
           };
         })
       : [];
-  };
-
-  /**
-   * Returns the currently selected domain for a term
-   *
-   * @param {Object} property
-   */
-  setSelectedDomain = (property) => {
-    /// Do not proceed if none selected
-    if (!property.selectedDomain) return null;
-
-    /// Instantiate the list of available domains
-    let domains = property.domain;
-
-    /// If it's only 1, return it
-    if (_.isString(domains)) return domains;
-
-    /// Get the currently selected domain
-    let selectedDomain = property.domain[property.selectedDomain];
-
-    /// Parse the response
-    return _.isString(selectedDomain)
-      ? selectedDomain
-      : readNodeAttribute(selectedDomain, "@id");
-  };
-
-  /**
-   * Returns the currently selected range for a term
-   *
-   * @param {Object} property
-   */
-  setSelectedRange = (property) => {
-    /// Do not proceed if none selected
-    if (!property.selectedRange) return null;
-
-    /// Instantiate the list of available ranges
-    let ranges = property.range;
-
-    /// If it's only 1, return it
-    if (_.isString(ranges)) return ranges;
-
-    /// Get the currently selected range
-    let selectedRange = property.range[property.selectedRange];
-
-    /// Parse the response
-    return _.isString(selectedRange)
-      ? selectedRange
-      : readNodeAttribute(selectedRange, "@id");
   };
 
   /**
@@ -128,7 +78,7 @@ export default class EditTerm extends Component {
       ? range.map((rng, i) => {
           return {
             id: i,
-            name: _.isString(rng) ? rng : readNodeAttribute(rng, "@id"),
+            name: readNodeAttribute(rng, "@id"),
           };
         })
       : [];
@@ -413,7 +363,7 @@ export default class EditTerm extends Component {
                               className="form-control"
                               name="scheme"
                               placeholder="Porperty Scheme"
-                              value={term.property.scheme}
+                              value={term.property.scheme || ""}
                               onChange={this.handlePropertyChange}
                               disabled={uploadingVocabulary}
                             />
@@ -438,8 +388,10 @@ export default class EditTerm extends Component {
 
                       <ExpandableOptions
                         options={this.domainsAsOptions(term.property.domain)}
-                        selectedOption={this.setSelectedDomain(term.property)}
-                        onClose={(domain) => this.handleDomainChange(domain.id)}
+                        selectedOption={term.property.selectedDomain}
+                        onClose={(domain) =>
+                          this.handleDomainChange(domain.name)
+                        }
                         cardCssClass={"with-shadow"}
                       />
                     </div>
@@ -449,8 +401,8 @@ export default class EditTerm extends Component {
 
                       <ExpandableOptions
                         options={this.rangeAsOptions(term.property.range)}
-                        selectedOption={this.setSelectedRange(term.property)}
-                        onClose={(range) => this.handleRangeChange(range.id)}
+                        selectedOption={term.property.selectedRange}
+                        onClose={(range) => this.handleRangeChange(range.name)}
                         cardCssClass={"with-shadow"}
                       />
                     </div>

--- a/app/javascript/components/mapping-to-domains/TermCard.jsx
+++ b/app/javascript/components/mapping-to-domains/TermCard.jsx
@@ -74,7 +74,9 @@ export default class TermCard extends Component {
             <div className="row">
               <div
                 className="col-1 cursor-pointer"
-                data-toggle="tooltip" data-placement="top" title="Revert selecting this term"
+                data-toggle="tooltip"
+                data-placement="top"
+                title="Revert selecting this term"
                 onClick={() => this.handleOnRevertMapping(term.id)}
               >
                 <i className="fas fa-times"></i>
@@ -104,10 +106,13 @@ export default class TermCard extends Component {
         <div
           className={
             "col-8 mb-3" +
-            (disableClick ? "" : selected ? "" : " cursor-pointer")
+            (disableClick || selected ? "" : " cursor-pointer")
           }
         >
-          {term.name}
+          <strong>{term.name}</strong>{" "}
+          {term.property.selectedDomain
+            ? " [" + term.property.selectedDomain + "]"
+            : ""}
         </div>
         <div className="col-4">
           <div className="float-right">

--- a/app/javascript/components/property-mapping-list/PropertiesList.jsx
+++ b/app/javascript/components/property-mapping-list/PropertiesList.jsx
@@ -1,3 +1,4 @@
+import { filter } from "lodash";
 import React, { Component } from "react";
 import fetchAlignmentsForSpineTerm from "../../services/fetchAlignmentsForSpineTerm";
 import fetchDomain from "../../services/fetchDomain";
@@ -6,6 +7,7 @@ import Loader from "../shared/Loader";
 import NoSpineAlert from "./NoSpineAlert";
 import PropertyAlignments from "./PropertyAlignments";
 import PropertyCard from "./PropertyCard";
+import { implementSpineSort } from "./SortOptions";
 
 /**
  * @description: The list of properties with its alignments. Contains all the information about the property
@@ -78,10 +80,14 @@ export default class PropertiesList extends Component {
    * Returns the list of properties filtered by the value the user typed in the searchbar
    */
   filteredProperties = () => {
-    const { inputValue, hideSpineTermsWithNoAlignments } = this.props;
+    const {
+      inputValue,
+      hideSpineTermsWithNoAlignments,
+      selectedSpineOrderOption,
+    } = this.props;
     const { properties } = this.state;
 
-    return properties.filter(
+    let filteredProps = properties.filter(
       (property) =>
         /// Filter by the search input value
         property.name.toLowerCase().includes(inputValue.toLowerCase()) &&
@@ -106,6 +112,8 @@ export default class PropertiesList extends Component {
               property.organizationId
             )))
     );
+
+    return implementSpineSort(filteredProps, selectedSpineOrderOption);
   };
 
   /**
@@ -220,6 +228,19 @@ export default class PropertiesList extends Component {
   };
 
   /**
+   * Set the alignment score from the calculation when its done
+   *
+   * @param {Object} property
+   * @param {Float} score
+   */
+  handleAlignmentScoreFetched = (property, score) => {
+    const { properties } = this.state;
+    property.alignmentScore = score;
+
+    this.setState({ properties: [...properties] });
+  };
+
+  /**
    * Tasks when the component updates itself
    */
   componentDidUpdate(prevProps) {
@@ -247,6 +268,7 @@ export default class PropertiesList extends Component {
     const {
       predicates,
       organizations,
+      selectedAlignmentOrderOption,
       selectedAlignmentOrganizations,
       selectedDomain,
       selectedPredicates,
@@ -268,10 +290,14 @@ export default class PropertiesList extends Component {
                 predicates={predicates}
                 selectedDomain={selectedDomain}
                 term={term}
+                onAlignmentScoreFetched={(score) =>
+                  this.handleAlignmentScoreFetched(term, score)
+                }
               />
             </div>
             <div className="col-8">
               <PropertyAlignments
+              selectedAlignmentOrderOption={selectedAlignmentOrderOption}
                 selectedAlignmentOrganizations={selectedAlignmentOrganizations}
                 selectedPredicates={selectedPredicates}
                 selectedSpineOrganizations={selectedSpineOrganizations}

--- a/app/javascript/components/property-mapping-list/PropertyAlignments.jsx
+++ b/app/javascript/components/property-mapping-list/PropertyAlignments.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import Loader from "../shared/Loader";
+import { implementAlignmentSort } from "./SortOptions";
 
 /**
  * @description A list of alignments with information like predicate, comment, and more.
@@ -8,6 +9,7 @@ import Loader from "../shared/Loader";
  * Props:
  * @param {Object} spineTerm The term of the spine to look for alignments
  * @param {Array} selectedPredicates The list of predicates selected by the user in the filter
+ * @param {String} selectedAlignmentOrderOption The option selected by the user to order the list of alignments
  * @param {Array} selectedAlignmentOrganizations The list of organizations that made alignments, selected by the user
  *   in the filter.
  * @param {Array} selectedSpineOrganizations The list of organizations that has properties with alignments, selected
@@ -56,10 +58,10 @@ export default class PropertyAlignments extends Component {
    * The list of alignments filtered using the values in the filters bar
    */
   filteredAlignments = () => {
-    const { spineTerm } = this.props;
+    const { spineTerm, selectedAlignmentOrderOption } = this.props;
     const { alignments } = this.state;
 
-    return alignments.filter(
+    let filteredAl = alignments.filter(
       (alignment) =>
         /// It matches the selected predicates
         this.selectedPredicateIds().includes(alignment.predicateId) &&
@@ -70,6 +72,8 @@ export default class PropertyAlignments extends Component {
         /// It matches the selected alignment organizations
         this.selectedSpineOrganizationIds().includes(spineTerm.organizationId)
     );
+
+    return implementAlignmentSort(filteredAl, selectedAlignmentOrderOption);
   };
 
   render() {
@@ -167,7 +171,7 @@ class AlignmentCard extends Component {
               <h5>{this.printMappedTermProperty("name")}</h5>
 
               <small className="mt-3 col-on-primary-light">Class/Type</small>
-              <h5>{this.printMappedTermProperty("uri")}</h5>
+              <h5>{alignment.mappedTerms[0].property.selectedDomain}</h5>
             </div>
             <div className="col-6">
               <small className="mt-3 col-on-primary-light">Definition</small>

--- a/app/javascript/components/property-mapping-list/PropertyCard.jsx
+++ b/app/javascript/components/property-mapping-list/PropertyCard.jsx
@@ -7,6 +7,7 @@ import ProgressReportBar from "../shared/ProgressReportBar";
 
 /**
  * Props:
+ * @param {Function} onAlignmentScoreFetched
  * @param {Array} organizations
  * @param {Array} predicates
  * @param {Object} term
@@ -33,18 +34,6 @@ export default class PropertyCard extends Component {
      * The maximum possible mapping weight value for this term
      */
     maxMappingWeight: 5,
-  };
-
-  /**
-   * Correctly fetch the organization name
-   *
-   * @param {Integer} orgId
-   */
-  getOrganizationName = (orgId) => {
-    const { organizations } = this.props;
-    let org = organizations.find((org) => org.id == orgId);
-
-    return org ? org.name : "Not found";
   };
 
   /**
@@ -118,6 +107,22 @@ export default class PropertyCard extends Component {
     });
   }
 
+  /**
+   * Actions to perform when this component os updated.
+   * It manages to execute the callback to set the score in the property
+   *
+   * @param {Object} prevProps
+   * @param {Object} prevState
+   */
+  componentDidUpdate(prevProps, prevState) {
+    const { currentMappingWeight, maxMappingWeight } = this.state;
+    const { onAlignmentScoreFetched } = this.props;
+
+    if (currentMappingWeight != prevState.currentMappingWeight) {
+      onAlignmentScoreFetched((currentMappingWeight * 100) / maxMappingWeight);
+    }
+  }
+
   render() {
     /**
      * Elements from props
@@ -147,15 +152,14 @@ export default class PropertyCard extends Component {
             <h3>{term.name}</h3>
 
             <small className="mt-3 col-on-primary-light">Class/Type</small>
-            <p>{selectedDomain.name}</p>
+            <p>{term.property.selectedDomain}</p>
 
             <small className="mt-3 col-on-primary-light">Definition</small>
             <p>{term.property.comment}</p>
 
             <small className="mt-3 col-on-primary-light">Organization</small>
-            <p>{this.getOrganizationName(term.organizationId)}</p>
+            <p>{term.organization.name}</p>
 
-            {/* ↓↓↓ TODO: Is this correct? ↓↓↓ */}
             <small className="mt-3 col-on-primary-light">Schema</small>
             <p>{term.property.scheme}</p>
 

--- a/app/javascript/components/property-mapping-list/SortOptions.jsx
+++ b/app/javascript/components/property-mapping-list/SortOptions.jsx
@@ -1,14 +1,16 @@
 /**
  * Options for sorting a collection of spine terms
+ *
+ * @todo Resolve the commented sort options
  */
 export const spineSortOptions = {
-  OVERALL_ALIGNMENT_SCORE:  "Overall Alignment Score",
+  OVERALL_ALIGNMENT_SCORE: "Overall Alignment Score",
   TOTAL_IDENTICAL_ALIGNMENTS: "Total Identical Alignments",
   ORGANIZATION: "Organization",
   SPINE_CLASS_TYPE: "Spine Class/Type",
   SPINE_PROPERTY: "Spine Property",
-  HAS_ALIGNMENT_ISSUES: "Has Alignment Issues",
-  SOURCE_DATA_ORDER: "Source Data Order",
+  // HAS_ALIGNMENT_ISSUES: "Has Alignment Issues",
+  // SOURCE_DATA_ORDER: "Source Data Order",
 };
 
 /**
@@ -20,5 +22,113 @@ export const alignmentSortOptions = {
   ALIGNMENT_SCORE: "Alignment Score",
   PROPERTY: "Property",
   HAS_ALIGNMENT_ISSUES: "Has Alignment Issues",
-  SOURCE_DATA_ORDER: "Source Data Order",
+};
+
+/**
+ * Returns the properties collection ordered by the selected criteria
+ *
+ * @param {Array} properties
+ * @param {String} sortOption
+ */
+export const implementSpineSort = (properties, sortOption) => {
+  switch (sortOption) {
+    /**
+     * Sort by alignment score. This is a number assigned via calculation in the frontend.
+     */
+    case spineSortOptions.OVERALL_ALIGNMENT_SCORE:
+      return properties.sort((a, b) => b.alignmentScore - a.alignmentScore);
+    /**
+     * @todo Find out the meaning of this sorting strategy.
+     */
+    case spineSortOptions.TOTAL_IDENTICAL_ALIGNMENTS:
+      return properties.sort((a, b) =>
+        a.alignments.filter(
+          (a) => a.predicate.prefLabel.toLowerCase() == "identical"
+        ).length <
+        b.alignments.filter(
+          (a) => a.predicate.prefLabel.toLowerCase() == "identical"
+        ).length
+          ? 1
+          : -1
+      );
+    /**
+     * Sort by organization name, since a property might be synthetic, meaning that a different
+     * organization than the spine added it.
+     */
+    case spineSortOptions.ORGANIZATION:
+      return properties.sort((a, b) =>
+        a.organization.name > b.organization.name ? 1 : -1
+      );
+    /**
+     * Sort by selected domain class of the property. This field can be edited in the edit term screen.
+     */
+    case spineSortOptions.SPINE_CLASS_TYPE:
+      return properties.sort((a, b) =>
+        a.property.selectedDomain > b.property.selectedDomain ? 1 : -1
+      );
+    /**
+     * Sort by the spine property name
+     */
+    case spineSortOptions.SPINE_PROPERTY:
+      return properties.sort((a, b) => (a.name > b.name ? 1 : -1));
+    /**
+     * @todo Find out the meaning of this sorting strategy
+     */
+    case spineSortOptions.HAS_ALIGNMENT_ISSUES:
+      return properties;
+    /**
+     * @todo Find out the meaning of this sorting strategy
+     */
+    case spineSortOptions.SOURCE_DATA_ORDER:
+      return properties;
+    default:
+      return properties;
+  }
+};
+
+/**
+ * Returns the properties collection ordered by the selected criteria.
+ *
+ * @param {Array} properties
+ * @param {String} sortOption
+ */
+export const implementAlignmentSort = (properties, sortOption) => {
+  switch (sortOption) {
+    /**
+     * Sort by the property organization name.
+     */
+    case alignmentSortOptions.ORGANIZATION:
+      return properties.sort((a, b) => (a.origin > b.origin ? 1 : -1));
+    /**
+     * Sort by selected domain class of the property. This field can be edited in the edit term screen.
+     */
+    case alignmentSortOptions.CLASS_TYPE:
+      return properties.sort((a, b) =>
+        a.mappedTerms[0].property.selectedDomain >
+        b.mappedTerms[0].property.selectedDomain
+          ? 1
+          : -1
+      );
+    /**
+     * Sort by the alignment weight.
+     */
+    case alignmentSortOptions.ALIGNMENT_SCORE:
+      return properties.sort((a, b) =>
+        a.predicate.weight > b.predicate.weight ? 1 : -1
+      );
+    /**
+     * Sort by the property name.
+     */
+    case alignmentSortOptions.PROPERTY:
+      return properties.sort((a, b) =>
+        a.mappedTerms[0].property.name > b.mappedTerms[0].property.name ? 1 : -1
+      );
+    /**
+     * Sort bringing those alignments that has comments first.
+     */
+    case alignmentSortOptions.HAS_ALIGNMENT_ISSUES:
+      return properties.sort((a, b) => (a.comment < b.comment ? 1 : -1));
+    default:
+      return properties;
+  }
 };

--- a/app/javascript/helpers/Vocabularies.js
+++ b/app/javascript/helpers/Vocabularies.js
@@ -99,10 +99,15 @@ export const cantConcepts = (vocab) => {
  * @param {String} attr
  */
 export const readNodeAttribute = (node, attr) => {
+  if (_.isNull(node)) return "";
+
+  /// Return straight if the node itself is a String
+  if (_.isString(node)) return node;
+
   let key = findNodeKey(node, attr);
   if (!key) return;
 
-  /// Return straight if it is a String
+  /// Return straight if the attribute is a String
   if (_.isString(node[key])) return node[key];
 
   /// We are reading an attribute that's not a String. It contains one more
@@ -132,13 +137,13 @@ export const readNodeAttribute = (node, attr) => {
 
 /**
  * Find the node key by approximation
- * 
- * @param {Object} node 
- * @param {String} attr 
+ *
+ * @param {Object} node
+ * @param {String} attr
  */
 const findNodeKey = (node, attr) => {
-  
-  var objectKeys = Object.keys(node).filter(k => k.includes(attr));
+  var objectKeys = Object.keys(node).filter((k) => k.includes(attr));
+
   return !_.isEmpty(objectKeys) ? objectKeys[0] : null;
 };
 

--- a/app/javascript/services/fetchMappingSelectedTerms.jsx
+++ b/app/javascript/services/fetchMappingSelectedTerms.jsx
@@ -1,12 +1,15 @@
+import { camelizeKeys } from "humps";
 import apiRequest from "./api/apiRequest";
 
 const fetchMappingSelectedTerms = async (mappingId) => {
-  return await apiRequest({
+  let response = await apiRequest({
     url: "/api/v1/mappings/" + mappingId + "/selected_terms",
     method: "get",
     defaultResponse: [],
-    successResponse: "terms"
+    successResponse: "terms",
   });
+
+  return camelizeKeys(response);
 };
 
 export default fetchMappingSelectedTerms;

--- a/app/javascript/services/fetchUser.jsx
+++ b/app/javascript/services/fetchUser.jsx
@@ -14,7 +14,7 @@ async function fetchUser(user_id) {
         fullname: response.user.fullname,
         email: response.user.email,
         organization_id: response.user.organization_id,
-        role_id: response.user.assignments[0].role_id,
+        role_id: response.user.roles[0].id,
       },
     };
   }

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -38,10 +38,18 @@ class Term < ApplicationRecord
   accepts_nested_attributes_for :property, allow_destroy: true
 
   ###
+  # @description: Include additional information about the specification in
+  #   json responses. This overrides the ApplicationRecord as_json method.
+  ###
+  def as_json(options={})
+    super options.merge(methods: %i[organization])
+  end
+
+  ###
   # @description: Build and return the uri with the "desm" prefix
   # @return [String]: the desm namespaced uri
   ###
-  def desm_uri
-    "desm-#{organization.name.downcase.strip}:#{uri.split(':').last}"
+  def desm_uri domain=nil
+    "desm-#{organization.name.downcase.strip}-#{domain&.pref_label&.downcase&.strip}:#{uri.split(':').last}"
   end
 end

--- a/app/services/parsers/specifications.rb
+++ b/app/services/parsers/specifications.rb
@@ -66,7 +66,12 @@ module Parsers
     # @return [Array]
     ###
     def self.read_as_array(node, attribute_name)
-      Array(read(node, attribute_name))
+      node_attribute = read(node, attribute_name)
+      values = Array(node_attribute) unless node_attribute.is_a?(Hash)
+      values = node_attribute.values if node_attribute.is_a?(Hash)
+
+      # We need the string values, each of it could be sorrounded by "@id" key as an object
+      values.map {|value| (value.is_a?(Hash) && (value[:@id] || value["@id"])) || value }
     end
 
     ###

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -12,7 +12,7 @@ module Processors
     ###
     def self.create(specification, user)
       name = "#{user.organization.name} - #{specification.domain.pref_label}"
-      spine = specification.domain.spine
+      @spine = specification.domain.spine
 
       ActiveRecord::Base.transaction do
         mapping = Mapping.create!(
@@ -20,7 +20,7 @@ module Processors
           title: name,
           user: user,
           specification: specification,
-          spine_id: spine.id
+          spine_id: @spine.id
         )
 
         create_mapping_terms(mapping)
@@ -39,10 +39,10 @@ module Processors
       terms = 0
       mapping.spine.terms.each do |term|
         # Do not create this term if there's already one with the same uri
-        next if MappingTerm.find_by(uri: term.desm_uri)
+        # next if MappingTerm.find_by(uri: term.desm_uri)
 
         MappingTerm.create!(
-          uri: term.desm_uri,
+          uri: term.desm_uri(@spine.domain),
           mapping: mapping,
           spine_term_id: term.id
         )

--- a/app/services/processors/specifications.rb
+++ b/app/services/processors/specifications.rb
@@ -339,16 +339,13 @@ module Processors
     ###
     def self.create_one_term(node)
       # Retrieve the term, if not found, create one with these properties
-      term = Term.find_or_initialize_by(uri: Parsers::Specifications.read!(node, "id")) do |t|
+      Term.find_or_initialize_by(uri: Parsers::Specifications.read!(node, "id")) do |t|
         t.update!(
           name: Parsers::Specifications.read!(node, "label"),
           organization: @current_user.organization
         )
+        create_property_term(t, node)
       end
-
-      create_property_term(term, node)
-
-      term
     end
 
     ###
@@ -359,14 +356,18 @@ module Processors
     def self.create_property_term term, node
       return if term.property.present?
 
+      domain = Parsers::Specifications.read_as_array(node, "domain")
+      range = Parsers::Specifications.read_as_array(node, "range")
+
       Property.create!(
         term: term,
         uri: term.desm_uri,
         source_uri: Parsers::Specifications.read!(node, "id"),
         comment: Parsers::Specifications.read!(node, "comment"),
         label: Parsers::Specifications.read!(node, "label"),
-        domain: Parsers::Specifications.read_as_array(node, "domain"),
-        range: Parsers::Specifications.read_as_array(node, "range"),
+        domain: domain,
+        selected_domain: domain&.first,
+        range: range&.first,
         subproperty_of: Parsers::Specifications.read!(node, "subproperty"),
         scheme: @scheme
       )

--- a/db/fixtures/organizations.rb
+++ b/db/fixtures/organizations.rb
@@ -1,6 +1,6 @@
 # Initial Organizations (change to valid ones)
 Organization.seed(:name,
-  { name: 'Schema.org' },
-  { name: 'CredReg' },
-  { name: 'CEDS' }
+  { name: 'Schema.org', email: "info@schema.org" },
+  { name: 'CredReg', email: "info@credreg.org" },
+  { name: 'CEDS', email: "info@ceds.org" }
 )

--- a/db/migrate/20201210183833_add_selected_domain_to_existent_properties.rb
+++ b/db/migrate/20201210183833_add_selected_domain_to_existent_properties.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSelectedDomainToExistentProperties < ActiveRecord::Migration[6.0]
+  def change
+    # The selected domain should exist. It can be one of the list of the available ones
+    Property.update_all("selected_domain = domain->>0")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_172343) do
+ActiveRecord::Schema.define(version: 2020_12_11_202144) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
# What was done?

### Define structure of sorting spine properties

### Implement the different alignment sorting criteria
- On the "Synthetic Spine Property Mapping By Category" screen, looking at the issue #71, implement the different criteria for sorting the alignments to a spine term.

### Ensure every property has its selectable domains collection
- Since different organizations specifies the available domain list for a property differently, we take care of ensuring that, in the end, we have a collection of string values to show the user in the edit term screen.

### Complete the spine sort options implementation
Options to sort spine properties available:
- "Overall Alignment Score"
- "Organization"
- "Spine Class/Type"
- "Spine Property"
- "Total Identical Alignments"

### Complete the alignment sort options implementation
Options to sort alignments available:
- "Organization"
- "Class/Type"
- "Alignment Score"
- "Property"
- "Has Alignment Issues"

### Options still unavailable for sorting spine terms (awaiting requirement clarifications)
- "Has Alignment Issues"
- "Source Data Order"
