### PR TITLE
Assign colors for predicates dynamically

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -173,6 +173,7 @@ a:hover {
 
 .selected-item {
   border-bottom: solid 4px $primary-color-light !important;
+  z-index: 3;
 }
 
 .desm-tab-item:hover {

--- a/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
+++ b/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
@@ -574,7 +574,10 @@ const AlignAndFineTune = (props) => {
    */
   const saveAllAlignments = async () => {
     /// Check for synthetic properties and save it if any
-    let synthetics = mappingTerms.filter((mTerm) => mTerm.synthetic);
+    /// Do not create a synthetic if it's already persisted
+    let synthetics = mappingTerms.filter(
+      (mTerm) => mTerm.synthetic & !mTerm.persisted
+    );
     let alignments = mappingTerms.filter(
       (mTerm) => !mTerm.synthetic && mTerm.changed
     );
@@ -674,8 +677,11 @@ const AlignAndFineTune = (props) => {
   const handleFetchMappingTerms = async (mappingId) => {
     let response = await fetchMappingTerms(mappingId);
     if (!anyError(response)) {
+      let mTerms = response.terms;
+      mTerms.forEach((term) => (term.persisted = true));
+
       // Set the mapping terms on state
-      setMappingTerms(response.terms);
+      setMappingTerms(mTerms);
     }
   };
 

--- a/app/javascript/components/property-mapping-list/PropertyAlignments.jsx
+++ b/app/javascript/components/property-mapping-list/PropertyAlignments.jsx
@@ -175,7 +175,13 @@ class AlignmentCard extends Component {
             </div>
             <div className="col-2">
               <div className="card borderless">
-                <div className="card-hader text-center bg-col-success col-background desm-rounded p-3">
+                <div
+                  className="card-hader text-center desm-rounded p-3"
+                  style={{
+                    backgroundColor: alignment.predicate.color || "unset",
+                    color: alignment.predicate.color ? "White" : "DarkSlateGrey"
+                   }}
+                >
                   <strong>
                     {alignment.predicate ? alignment.predicate.prefLabel : ""}
                   </strong>

--- a/app/models/predicate.rb
+++ b/app/models/predicate.rb
@@ -17,4 +17,108 @@
 class Predicate < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
   validates :pref_label, presence: true
+  before_create :assign_color, unless: :color?
+
+  MAX_ALLOWED_WEIGHT = 5
+  MIN_ALLOWED_WEIGHT = 0
+
+  ###
+  # @description: Map of labels
+  ###
+  DEFAULT_LABELS = {
+    aggregated: "aggregated",
+    concept: "concept",
+    disaggregated: "disaggregated",
+    identical: "identical",
+    issue: "issue",
+    no_match: "no match",
+    not_applicable: "not applicable",
+    reworded: "reworded",
+    similar: "similar"
+  }.freeze
+
+  ###
+  # @description: Map of colors
+  ###
+  COLORS = {
+    dark_blue: "DarkBlue",
+    dark_green: "DarkGreen",
+    light_blue: "LightBlue",
+    light_green: "LimeGreen",
+    orange: "Orange",
+    red: "Red",
+    pink: "Pink",
+    unset: "unset",
+    yellow: "Yellow"
+  }.freeze
+
+  ###
+  # @description: Map of weights and colors. These colors for predicates depending on weights is
+  #   an agreement from a github issue.
+  # @see https://github.com/t3-innovation-network/desm/issues/72
+  ###
+  WEIGHT_COLORS = {
+    0 => {
+      DEFAULT_LABELS[:no_match] => COLORS[:red],
+      DEFAULT_LABELS[:not_applicable] => COLORS[:unset]
+    },
+    1 => {
+      DEFAULT_LABELS[:issue] => COLORS[:pink]
+    },
+    2 => {
+      DEFAULT_LABELS[:concept] => COLORS[:orange]
+    },
+    3 => {
+      DEFAULT_LABELS[:disaggregated] => COLORS[:light_blue],
+      DEFAULT_LABELS[:aggregated] => COLORS[:dark_blue]
+    },
+    4 => {
+      DEFAULT_LABELS[:similar] => COLORS[:yellow]
+    },
+    5 => {
+      DEFAULT_LABELS[:reworded] => COLORS[:light_green],
+      DEFAULT_LABELS[:identical] => COLORS[:dark_green]
+    }
+  }.freeze
+
+  ###
+  # @description: Assigns a color depending on the weight and the label
+  #   NOTE: This logic may change in future phases of this project to let an admin select the color
+  #   using the dashboard.
+  ###
+  def assign_color
+    self.color = weight_to_color
+  end
+
+  private
+
+  ###
+  # @description: Returns the color string for this predicate instance
+  # @return [String]
+  ###
+  def weight_to_color
+    # Validate weight is inside the permitted range, and the label is in the collection of default
+    # labels, otherwise do not assign a color.
+    return nil unless weight_is_valid? && label_is_valid?
+
+    WEIGHT_COLORS.dig(weight.to_i, pref_label.downcase)
+  end
+
+  ###
+  # @description: Determines the validity of the weight
+  # @return [TrueClass|FalseClass]
+  ###
+  def weight_is_valid?
+    (MIN_ALLOWED_WEIGHT..MAX_ALLOWED_WEIGHT).include?(weight.to_i)
+  end
+
+  ###
+  # @description: Determines the validity of the label.
+  # @return [TrueClass|FalseClass]
+  ###
+  def label_is_valid?
+    snake_cased_label = pref_label.parameterize.underscore
+
+    DEFAULT_LABELS.keys.include?(snake_cased_label.to_sym)
+  end
 end

--- a/db/fixtures/organizations.rb
+++ b/db/fixtures/organizations.rb
@@ -1,6 +1,6 @@
 # Initial Organizations (change to valid ones)
 Organization.seed(:name,
-  { name: 'Schema.org' },
-  { name: 'CredReg' },
-  { name: 'CEDS' }
+  { name: 'Schema.org', email: "info@schema.org" },
+  { name: 'CredReg', email: "info@credreg.org" },
+  { name: 'CEDS', email: "info@ceds.org" }
 )

--- a/db/migrate/20201207172343_add_scheme_to_properties.rb
+++ b/db/migrate/20201207172343_add_scheme_to_properties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSchemeToProperties < ActiveRecord::Migration[6.0]
   def change
     change_table :properties do |t|

--- a/db/migrate/20201211202144_add_color_for_predicates.rb
+++ b/db/migrate/20201211202144_add_color_for_predicates.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddColorForPredicates < ActiveRecord::Migration[6.0]
+  def change
+    change_table :predicates do |t|
+      t.string :color
+    end
+
+    ###
+    # @description: This change might affect existent records. The solution is to run the "assign_color" method
+    #   to ensure the field is correctly populated to all those that hasn't.
+    #   If, for any reason, this method doesn't remain in the future, replace it by assigning the color using
+    #   the console or a rake task.
+    ###
+    Predicate.find_each {|p|
+      next unless p.respond_to?(:assign_color) && !p.color.present?
+      p.assign_color
+      p.save!
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_172343) do
+ActiveRecord::Schema.define(version: 2020_12_11_202144) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -150,6 +151,7 @@ ActiveRecord::Schema.define(version: 2020_12_07_172343) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.float "weight", default: 0.0, null: false
+    t.string "color"
     t.index ["uri"], name: "index_predicates_on_uri", unique: true
   end
 


### PR DESCRIPTION
# What was done?

Taking the instructions on issue [N#72](https://github.com/t3-innovation-network/desm/issues/72),
assign colors for each predicate on creation and for existent ones (migration and model method).

# Screenshots
![image](https://user-images.githubusercontent.com/6996951/101984957-69d61a00-3c63-11eb-91f2-09277efe7e0c.png)
