### PR TITLE
Permit to change the status of a mapping

### DIFF
--- a/app/controllers/api/v1/mappings_controller.rb
+++ b/app/controllers/api/v1/mappings_controller.rb
@@ -5,15 +5,14 @@
 ###
 class Api::V1::MappingsController < ApplicationController
   before_action :authorize_with_policy
+  before_action :instantiate_specification, only: :create
 
   ###
   # @description: Creates a mapping with its related specification
   ###
   def create
-    spec = Specification.find(params[:specification_id])
-
     # Proceed to create the mapping if this is not the spine
-    @instance = Processors::Mappings.create(spec, current_user) unless spec.spine?
+    @instance = Processors::Mappings.new(@specification, current_user).create unless @specification.spine?
 
     render json: @instance, include: :specification
   end
@@ -63,7 +62,7 @@ class Api::V1::MappingsController < ApplicationController
   end
 
   ###
-  # @description: Udates the attributes of a mapping
+  # @description: Updates the attributes of a mapping
   ###
   def update
     @instance.update!(permitted_params)
@@ -93,6 +92,15 @@ class Api::V1::MappingsController < ApplicationController
 
     # Return an ordered list
     mappings.order(:title)
+  end
+
+  ###
+  # @description: Find the specification with the id passed in params
+  ###
+  def instantiate_specification
+    raise "Specification id not provided" unless params[:specification_id].present?
+
+    @specification = Specification.find(params[:specification_id])
   end
 
   ###

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   # Handle errors with a concern
-  include Recoverable
+  # include Recoverable
 
   # We manage our own security for sessions
   skip_before_action :verify_authenticity_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   # Handle errors with a concern
-  # include Recoverable
+  include Recoverable
 
   # We manage our own security for sessions
   skip_before_action :verify_authenticity_token

--- a/app/javascript/components/specifications-list/SpecsList.jsx
+++ b/app/javascript/components/specifications-list/SpecsList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Fragment } from "react";
+import React, { Fragment } from "react";
 import TopNav from "../shared/TopNav";
 import { Link } from "react-router-dom";
 import fetchMappings from "../../services/fetchMappings";
@@ -11,56 +11,53 @@ import { toastr as toast } from "react-redux-toastr";
 import deleteMapping from "../../services/deleteMapping";
 import fetchMappingToExport from "../../services/fetchMappingToExport";
 import { downloadFile } from "../../helpers/Export";
+import updateMapping from "../../services/updateMapping";
+import { Component } from "react";
 
-const SpecsList = () => {
-  /**
-   * Controls displaying the removal confirmation dialog
-   */
-  const [confirmingRemove, setConfirmingRemove] = useState(false);
-  /**
-   * Representation of an error on this page process
-   */
-  const [errors, setErrors] = useState([]);
-  /**
-   * Representation of an error on this page process while removing a mapping
-   */
-  const [errorsWhileRemoving, setErrorsWhileRemoving] = useState([]);
-  /**
-   * Represents the filter value to configure the query to get the specifications
-   */
-  const [filter, setFilter] = useState("user");
-  /**
-   * Whether the page is loading results or not
-   */
-  const [loading, setLoading] = useState(true);
-  /**
-   * The list of mappings to display
-   */
-  const [mappings, setMappings] = useState([]);
-  /**
-   * The identifier of the mapping to be removed. Saved in state, because the id is in an iterator,
-   * and the clicked handles confirmation, and the confirmation is outside the iterator.
-   */
-  const [mappingIdToRemove, setMappingIdToRemove] = useState(null);
-  /**
-   * The options object to use in the select component
-   */
-  const filterOptions = [
-    {
-      key: "user",
-      value: "Only My Mappings",
-    },
-    {
-      key: "all",
-      value: "All Mappings",
-    },
-  ];
-
-  /**
-   * Configure the options to see at the center of the top navigation bar
-   */
-  const navCenterOptions = () => {
-    return <TopNavOptions viewMappings={true} mapSpecification={true} />;
+export default class SpecsList extends Component {
+  state = {
+    /**
+     * Controls displaying the removal confirmation dialog
+     */
+    confirmingRemove: false,
+    /**
+     * Representation of an error on this page process
+     */
+    errors: [],
+    /**
+     * Representation of an error on this page process while removing a mapping
+     */
+    errorsWhileRemoving: [],
+    /**
+     * Represents the filter value to configure the query to get the specifications
+     */
+    filter: "user",
+    /**
+     * Whether the page is loading results or not
+     */
+    loading: true,
+    /**
+     * The list of mappings to display
+     */
+    mappings: [],
+    /**
+     * The identifier of the mapping to be removed. Saved in state, because the id is in an iterator,
+     * and the clicked handles confirmation, and the confirmation is outside the iterator.
+     */
+    mappingIdToRemove: null,
+    /**
+     * The options object to use in the select component
+     */
+    filterOptions: [
+      {
+        key: "user",
+        value: "Only My Mappings",
+      },
+      {
+        key: "all",
+        value: "All Mappings",
+      },
+    ],
   };
 
   /**
@@ -68,12 +65,13 @@ const SpecsList = () => {
    *
    * @param {HttpResponse} response
    * @param {Array} errorsList
-   * @param {Function} updateErrors
    */
-  function anyError(response, errorsList, updateErrors) {
+  anyError(response, errorsList = this.state.errors) {
     if (response.error) {
       errorsList.push(response.error);
-      updateErrors([...new Set(errorsList)]);
+      this.setState({
+        errorsList: [...new Set(errorsList)],
+      });
     }
     /// It will return a truthy value (depending no the existence
     /// of the errors on the response object)
@@ -81,11 +79,30 @@ const SpecsList = () => {
   }
 
   /**
+   * Use effect with an empty array as second parameter, will trigger the 'goForTheMapping'
+   * action at the 'mounted' event of this functional component (It's not actually mounted,
+   * but it mimics the same action).
+   */
+  componentDidMount() {
+    const { errors } = this.state;
+
+    this.goForTheMappings().then(() => {
+      if (!errors.length) {
+        this.setState({
+          loading: false,
+        });
+      }
+    });
+  }
+
+  /**
    * Actions to take when the user confirms to remove a mapping
    */
-  const handleConfirmRemove = (mappingId) => {
-    setConfirmingRemove(true);
-    setMappingIdToRemove(mappingId);
+  handleConfirmRemove = (mappingId) => {
+    this.setState({
+      confirmingRemove: true,
+      mappingIdToRemove: mappingId,
+    });
   };
 
   /**
@@ -94,10 +111,10 @@ const SpecsList = () => {
    *
    * @param {Integer} mappingId
    */
-  const handleExportMapping = async (mappingId) => {
+  handleExportMapping = async (mappingId) => {
     let response = await fetchMappingToExport(mappingId);
 
-    if (!anyError(response)) {
+    if (!this.anyError(response)) {
       downloadFile(response.exportedMapping);
     }
   };
@@ -105,228 +122,300 @@ const SpecsList = () => {
   /**
    * Send a request to delete the selected mapping.
    */
-  const handleRemoveMapping = async () => {
+  handleRemoveMapping = async () => {
+    const { errorsWhileRemoving, mappings, mappingIdToRemove } = this.state;
     let response = await deleteMapping(mappingIdToRemove);
 
-    if (!anyError(response, errorsWhileRemoving, setErrorsWhileRemoving)) {
+    if (!this.anyError(response, errorsWhileRemoving)) {
       toast.success("Mapping removed");
 
-      setMappings(
-        mappings.filter((mapping) => mapping.id !== mappingIdToRemove)
-      );
-      setConfirmingRemove(false);
+      this.setState({
+        mappings: mappings.filter(
+          (mapping) => mapping.id !== mappingIdToRemove
+        ),
+        confirmingRemove: false,
+      });
     }
   };
 
   /**
    * Change the filter for the listed mappings
    */
-  const handleFilterChange = async (value) => {
-    setFilter(value);
-    await goForTheMappings(value);
+  handleFilterChange = async (value) => {
+    this.setState({
+      filter: value,
+    });
+    await this.goForTheMappings(value);
+  };
+
+  /**
+   * Mark a 'mapped' mapping back to 'in-progress'
+   *
+   * @param {int} mappingId
+   */
+  handleMarkToInProgress = async (mappingId) => {
+    const { mappings } = this.state;
+
+    this.setState({ loading: true });
+
+    /// Change the mapping status to "mapped", so we confirm it's finish the
+    /// mapping phase
+    let response = await updateMapping({
+      id: mappingId,
+      status: "in_progress",
+    });
+
+    if (!this.anyError(response)) {
+      /// Change 'in-memory' status
+      let mapping = mappings.find((m) => m.id === mappingId);
+      mapping.status = "in_progress";
+      mapping["mapped?"] = false;
+
+      this.setState(
+        {
+          mappings: [...mappings],
+        },
+        () => {
+          this.setState({ loading: false });
+        }
+      );
+
+      /// Notify the user
+      toast.success("Status changed!");
+    }
+
+    this.setState({ loading: false });
   };
 
   /**
    * Get the mappings from the service
    */
-  const goForTheMappings = async (value) => {
+  goForTheMappings = async (value) => {
+    const { errors, filter } = this.state;
+
     let filterValue = value || filter;
     let response = await fetchMappings(filterValue);
 
-    if (!anyError(response, errors, setErrors)) {
-      setMappings(response.mappings);
+    if (!this.anyError(response, errors)) {
+      this.setState({
+        mappings: response.mappings,
+      });
     }
   };
 
   /**
-   * Use effect with an empty array as second parameter, will trigger the 'goForTheMapping'
-   * action at the 'mounted' event of this functional component (It's not actually mounted,
-   * but it mimics the same action).
+   * Configure the options to see at the center of the top navigation bar
    */
-  useEffect(() => {
-    goForTheMappings().then(() => {
-      if (!errors.length) {
-        setLoading(false);
-      }
-    });
-  }, []);
+  navCenterOptions = () => {
+    return <TopNavOptions viewMappings={true} mapSpecification={true} />;
+  };
 
-  return (
-    <div className="wrapper">
-      <TopNav centerContent={navCenterOptions} />
-      <div className="container-fluid container-wrapper">
-        <div className="row">
-          <div className="col p-lg-5 pt-5">
-            <h4>My Specifications</h4>
-            {loading ? (
-              <Loader />
-            ) : (
-              <Fragment>
-                <ConfirmDialog
-                  onRequestClose={() => setConfirmingRemove(false)}
-                  onConfirm={() => handleRemoveMapping()}
-                  visible={confirmingRemove}
-                >
-                  <h2 className="text-center">
-                    You are removing a specification
-                  </h2>
-                  <h5 className="mt-3 text-center">
-                    Please confirm this action.
-                  </h5>
-                </ConfirmDialog>
+  render() {
+    const {
+      confirmingRemove,
+      filter,
+      filterOptions,
+      loading,
+      mappings,
+    } = this.state;
 
-                <div className="table-responsive">
-                  <table className="table">
-                    <thead>
-                      <tr>
-                        <th scope="col">Specification Name</th>
-                        <th scope="col">Version</th>
-                        <th scope="col">Mapped</th>
-                        <th scope="col">Status</th>
-                        <th scope="col">Author</th>
-                        <th scope="col">
-                          <select
-                            className="form-control"
-                            value={filter}
-                            onChange={(e) => handleFilterChange(e.target.value)}
-                          >
-                            {filterOptions.map(function (option) {
-                              return (
-                                <option key={option.key} value={option.key}>
-                                  {option.value}
-                                </option>
-                              );
-                            })}
-                          </select>
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <SpineSpecsList filter={filter} />
-                      {mappings.length > 0 ? (
-                        mappings.map((mapping) => {
-                          return (
-                            <tr key={mapping.id}>
-                              <td>{mapping.title}</td>
-                              <td>{mapping.specification.version}</td>
-                              <td>
-                                {mapping.mapped_terms +
-                                  "/" +
-                                  mapping.selected_terms.length}
-                              </td>
-                              <td>{_.startCase(_.toLower(mapping.status))}</td>
-                              <td>{mapping.specification.user.fullname}</td>
-                              <td>
-                                {mapping["mapped?"] ? (
-                                  <Link
-                                    to={"/mappings/" + mapping.id + "/align"}
-                                    className="btn btn-sm btn-dark ml-2"
-                                    data-toggle="tooltip"
-                                    data-placement="top"
-                                    title="Edit this mapping"
-                                  >
-                                    <i className="fas fa-pencil-alt"/>
-                                  </Link>
-                                ) : (
-                                  <Link
-                                    to={
-                                      mapping["uploaded?"]
-                                        ? /// This mapping has mapped terms, but it has not finished selecting the terms from the specification
-                                          "/mappings/" + mapping.id
-                                        : /// It's on the 3d step (align and fine tune), already selected the terms from the specification, and
-                                          /// now it's mapping terms into the spine terms
-                                          "/mappings/" + mapping.id + "/align"
-                                    }
-                                    className="btn btn-sm ml-2 bg-col-primary col-background"
-                                    data-toggle="tooltip"
-                                    data-placement="top"
-                                    title="Resume, continue mapping"
-                                  >
-                                    <i className="fas fa-layer-group"/>
-                                  </Link>
-                                )}
+    return (
+      <div className="wrapper">
+        <TopNav centerContent={this.navCenterOptions} />
+        <div className="container-fluid container-wrapper">
+          <div className="row">
+            <div className="col p-lg-5 pt-5">
+              <h4>My Specifications</h4>
+              {loading ? (
+                <Loader />
+              ) : (
+                <Fragment>
+                  <ConfirmDialog
+                    onRequestClose={() =>
+                      this.setState({ confirmingRemove: false })
+                    }
+                    onConfirm={() => this.handleRemoveMapping()}
+                    visible={confirmingRemove}
+                  >
+                    <h2 className="text-center">
+                      You are removing a specification
+                    </h2>
+                    <h5 className="mt-3 text-center">
+                      Please confirm this action.
+                    </h5>
+                  </ConfirmDialog>
 
-                                {mapping["mapped?"] ? (
-                                  <Link
-                                    to={
-                                      "/mappings-list?abstractClass=" +
-                                      mapping.domain
-                                    }
-                                    className="btn btn-sm btn-dark ml-2"
-                                    data-toggle="tooltip"
-                                    data-placement="top"
-                                    title="View this mapping"
-                                  >
-                                    <i className="fas fa-eye"/>
-                                  </Link>
-                                ) : (
-                                  ""
-                                )}
+                  <div className="table-responsive">
+                    <table className="table">
+                      <thead>
+                        <tr>
+                          <th scope="col">Specification Name</th>
+                          <th scope="col">Version</th>
+                          <th scope="col">Mapped</th>
+                          <th scope="col">Status</th>
+                          <th scope="col">Author</th>
+                          <th scope="col">
+                            <select
+                              className="form-control"
+                              value={filter}
+                              onChange={(e) =>
+                                this.handleFilterChange(e.target.value)
+                              }
+                            >
+                              {filterOptions.map(function (option) {
+                                return (
+                                  <option key={option.key} value={option.key}>
+                                    {option.value}
+                                  </option>
+                                );
+                              })}
+                            </select>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <SpineSpecsList filter={filter} />
+                        {mappings.length > 0 ? (
+                          mappings.map((mapping) => {
+                            return (
+                              <tr key={mapping.id}>
+                                <td>{mapping.title}</td>
+                                <td>{mapping.specification.version}</td>
+                                <td>
+                                  {mapping.mapped_terms +
+                                    "/" +
+                                    mapping.selected_terms.length}
+                                </td>
+                                <td>
+                                  {_.startCase(_.toLower(mapping.status))}
+                                </td>
+                                <td>{mapping.specification.user.fullname}</td>
+                                <td>
+                                  {mapping["mapped?"] ? (
+                                    <Link
+                                      to={"/mappings/" + mapping.id + "/align"}
+                                      className="btn btn-sm btn-dark ml-2"
+                                      data-toggle="tooltip"
+                                      data-placement="top"
+                                      title="Edit this mapping"
+                                    >
+                                      <i className="fas fa-pencil-alt" />
+                                    </Link>
+                                  ) : (
+                                    <Link
+                                      to={
+                                        mapping["uploaded?"]
+                                          ? /// This mapping has mapped terms, but it has not finished selecting the terms from the specification
+                                            "/mappings/" + mapping.id
+                                          : /// It's on the 3d step (align and fine tune), already selected the terms from the specification, and
+                                            /// now it's mapping terms into the spine terms
+                                            "/mappings/" + mapping.id + "/align"
+                                      }
+                                      className="btn btn-sm ml-2 bg-col-primary col-background"
+                                      data-toggle="tooltip"
+                                      data-placement="top"
+                                      title="Resume, continue mapping"
+                                    >
+                                      <i className="fas fa-layer-group" />
+                                    </Link>
+                                  )}
 
-                                <button
-                                  onClick={() =>
-                                    handleConfirmRemove(mapping.id)
-                                  }
-                                  className="btn btn-sm btn-dark ml-2"
-                                  data-toggle="tooltip"
-                                  data-placement="top"
-                                  title="Remove this mapping"
-                                >
-                                  <i className="fas fa-trash"/>
-                                </button>
-                                {mapping["mapped?"] ? (
+                                  {mapping["mapped?"] ? (
+                                    <Link
+                                      to={
+                                        "/mappings-list?abstractClass=" +
+                                        mapping.domain
+                                      }
+                                      className="btn btn-sm btn-dark ml-2"
+                                      data-toggle="tooltip"
+                                      data-placement="top"
+                                      title="View this mapping"
+                                    >
+                                      <i className="fas fa-eye" />
+                                    </Link>
+                                  ) : (
+                                    ""
+                                  )}
+
                                   <button
-                                    className="btn btn-sm btn-dark ml-2"
                                     onClick={() =>
-                                      handleExportMapping(mapping.id)
+                                      this.handleConfirmRemove(mapping.id)
                                     }
+                                    className="btn btn-sm btn-dark ml-2"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="Export this mapping"
+                                    title="Remove this mapping"
                                   >
-                                    <i className="fas fa-download"/>
+                                    <i className="fas fa-trash" />
                                   </button>
-                                ) : (
-                                  ""
-                                )}
-                              </td>
-                            </tr>
-                          );
-                        })
-                      ) : (
-                        <tr/>
-                      )}
-                    </tbody>
-                  </table>
+                                  {mapping["mapped?"] ? (
+                                    <Fragment>
+                                      <button
+                                        className="btn btn-sm btn-dark ml-2"
+                                        onClick={() =>
+                                          this.handleExportMapping(mapping.id)
+                                        }
+                                        data-toggle="tooltip"
+                                        data-placement="top"
+                                        title="Export this mapping"
+                                      >
+                                        <i className="fas fa-download" />
+                                      </button>
 
-                  <hr className="rounded-divider" />
+                                      <button
+                                        className="btn btn-sm btn-dark ml-2"
+                                        onClick={() =>
+                                          this.handleMarkToInProgress(
+                                            mapping.id
+                                          )
+                                        }
+                                        data-toggle="tooltip"
+                                        data-placement="top"
+                                        title="Mark this mapping back to 'in progress'"
+                                      >
+                                        <i className="fas fa-undo"/>
+                                      </button>
+                                    </Fragment>
+                                  ) : (
+                                    ""
+                                  )}
+                                </td>
+                              </tr>
+                            );
+                          })
+                        ) : (
+                          <tr />
+                        )}
+                      </tbody>
+                    </table>
 
-                  {mappings.length === 0 && (
-                    <div className="card text-center">
-                      <div className="card-header bg-col-on-primary-highlight">
-                        <p>
-                          All the specifications you and your team map will be
-                          visible here
-                        </p>
+                    <hr className="rounded-divider" />
+
+                    {mappings.length === 0 && (
+                      <div className="card text-center">
+                        <div className="card-header bg-col-on-primary-highlight">
+                          <p>
+                            All the specifications you and your team map will be
+                            visible here
+                          </p>
+                        </div>
+                        <div className="card-body bg-col-on-primary-highlight">
+                          <Link
+                            to="/new-mapping"
+                            className="btn bg-col-primary col-background"
+                          >
+                            Map a specification
+                          </Link>
+                        </div>
                       </div>
-                      <div className="card-body bg-col-on-primary-highlight">
-                        <Link
-                          to="/new-mapping"
-                          className="btn bg-col-primary col-background"
-                        >
-                          Map a specification
-                        </Link>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </Fragment>
-            )}
+                    )}
+                  </div>
+                </Fragment>
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-};
-
-export default SpecsList;
+    );
+  }
+}

--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -9,8 +9,7 @@
 ###
 class Mapping < ApplicationRecord
   ###
-  # @description: This will allow to keep track of every change in this model thorugh
-  #   the 'audits' method
+  # @description: This will allow to keep track of every change in this model using the 'audits' method
   ###
   audited
 
@@ -31,7 +30,7 @@ class Mapping < ApplicationRecord
   ###
   belongs_to :spine, foreign_key: "spine_id", class_name: :Specification
   ###
-  # @description: Each term that conforms the mapping. The terms of the mapping contains informatio
+  # @description: Each term that conforms the mapping. The terms of the mapping contains information
   #   about the type of alignment (predicate), which term from the spine was mapped to which of the
   #   original specification, and more.
   ###
@@ -59,6 +58,21 @@ class Mapping < ApplicationRecord
   enum status: {uploaded: 0, in_progress: 1, mapped: 2}
 
   ###
+  # CALLBACKS
+  ###
+
+  ###
+  # @description: Every mapping should have the same number of terms as the associated spine terms
+  ###
+  after_create :generate_alignments
+
+  ###
+  # @description: Remove all mapped terms from every alignment if we're going to
+  #   mark the mapping back as "uploaded"
+  ###
+  around_update :remove_alignments_mapped_terms, if: proc { status_changed? && uploaded? }
+
+  ###
   # METHODS
   ###
 
@@ -68,6 +82,19 @@ class Mapping < ApplicationRecord
   ###
   def as_json(options={})
     super options.merge(methods: %i[uploaded? mapped? in_progress? origin spine_origin domain mapped_terms])
+  end
+
+  ###
+  # @description: Creates the terms for the mapping (alignments).
+  ###
+  def generate_alignments
+    spine.terms.each do |term|
+      Alignment.create!(
+        uri: term.desm_uri(spine.domain),
+        mapping: self,
+        spine_term_id: term.id
+      )
+    end
   end
 
   ###
@@ -120,7 +147,18 @@ class Mapping < ApplicationRecord
   end
 
   ###
-  # @description: The organization that originated this the spine
+  # @description: Remove all alignments from a mapping
+  ###
+  def remove_alignments_mapped_terms
+    terms.each {|term|
+      term.mapped_term_ids = []
+      term.predicate_id = nil
+      term.save!
+    }
+  end
+
+  ###
+  # @description: The organization that originated the spine
   # @return [String]
   ###
   def spine_origin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   ###
   include Tokenable
   ###
-  # @description: Added because Tokenable needs the model that inclides it to have a "token" named attribute
+  # @description: Added because Tokenable needs the model that includes it to have a "token" named attribute
   ###
   alias_attribute :token, :reset_password_token
 
@@ -66,7 +66,7 @@ class User < ApplicationRecord
     ###
     min_entropy: 15,
     ###
-    # @description: The mimimum acceptable length of the password.
+    # @description: The minimum acceptable length of the password.
     ###
     min_word_length: MIN_PASSWORD_LENGTH,
     ###

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -6,25 +6,27 @@ module Processors
   ###
   class Mappings
     ###
-    # @description: Create the mapping entry from a specification
-    #
-    # @param [Specification] specification The specification that this mapping is created from
+    # @description: Initializes the mapping processor with a specification and a user
+    # @param specification [Specification] The specification that this mapping is created from
+    # @param user [User]
     ###
-    def self.create(specification, user)
-      name = "#{user.organization.name} - #{specification.domain.pref_label}"
-      @spine = specification.domain.spine
+    def initialize specification, user
+      @specification = specification
+      @user = user
+    end
 
-      ActiveRecord::Base.transaction do
-        mapping = Mapping.create!(
-          name: name,
-          title: name,
-          user: user,
-          specification: specification,
-          spine_id: @spine.id
-        )
-
-        mapping
-      end
+    ###
+    # @description: Create the mapping instance from a specification
+    ###
+    def create
+      name = "#{@user.organization.name} - #{@specification.domain.pref_label}"
+      Mapping.create!(
+        name: name,
+        title: name,
+        user: @user,
+        specification: @specification,
+        spine: @specification.domain.spine
+      )
     end
   end
 end

--- a/app/services/processors/mappings.rb
+++ b/app/services/processors/mappings.rb
@@ -23,39 +23,8 @@ module Processors
           spine_id: @spine.id
         )
 
-        create_alignments(mapping)
-
         mapping
       end
-    end
-
-    ###
-    # @description: Creates the terms for the mapping (alignments).
-    # @param [Mapping] mapping: The mapping for which the terms are going to be created.
-    #
-    # @return [Array]
-    ###
-    def self.create_alignments mapping
-      terms = 0
-      mapping.spine.terms.each do |term|
-        # Do not create this term if there's already one with the same uri
-        # next if Alignment.find_by(uri: term.desm_uri)
-
-        Alignment.create!(
-          uri: term.desm_uri(@spine.domain),
-          mapping: mapping,
-          spine_term_id: term.id
-        )
-
-        terms += 1
-      end
-
-      # The mapping should have terms assigned
-      return if terms.positive?
-
-      throw "Could not create candidate alignments because the terms already "\
-        "exists in our records. Please review the previously uploaded specifications "\
-        "and mappings"
     end
   end
 end

--- a/spec/factories/mappings.rb
+++ b/spec/factories/mappings.rb
@@ -8,11 +8,11 @@ FactoryBot.define do
     title { Faker::App.name }
     description { Faker::Lorem.sentence }
     user
-    specification
-    with_spine
+    with_spine_and_spec
 
-    trait :with_spine do
-      spine { Specification.new }
+    trait :with_spine_and_spec do
+      spine { FactoryBot.build(:specification) }
+      specification { FactoryBot.build(:specification) }
     end
   end
 end

--- a/spec/factories/specifications.rb
+++ b/spec/factories/specifications.rb
@@ -8,5 +8,13 @@ FactoryBot.define do
     uri { Faker::Lorem.sentence }
     user
     domain
+    with_terms
+
+    trait :with_terms do
+      after(:build) do |spec|
+        spec.terms = FactoryBot.build_list(:term, 10)
+        spec.save
+      end
+    end
   end
 end

--- a/spec/models/mapping_spec.rb
+++ b/spec/models/mapping_spec.rb
@@ -9,4 +9,28 @@ describe Mapping, type: :model do
 
   it { should validate_presence_of(:name) }
   it { should belong_to(:user) }
+
+  describe ".remove_alignments_mapped_terms" do
+    subject { FactoryBot.create(:mapping, status: 1) }
+    let(:predicate) { FactoryBot.build(:predicate) }
+
+    it "has empty alignments after it is marked back as 'uploaded'" do
+      # Randomly make the alignments
+      subject.terms.each {|alignment|
+        alignment.predicate_id = predicate
+        alignment.update_mapped_terms([
+                                        subject.specification.terms.map(&:id).sample
+                                      ])
+      }
+
+      # This should trigger the around_update hook called remove_alignments_mapped_terms
+      subject.status = 0
+      subject.save!
+
+      alignment = subject.terms.first
+
+      expect(alignment.predicate_id).to be_nil
+      expect(alignment.mapped_terms).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
# What was done?

Permit to change the status of a mapping
    
- When a mapping is marked as "mapped" (finished), now we can decide to put it back to "in-progress". Doing this will allow us to change a predicate, and/or the terms of the specification.

- In addition, we also can grab a mapping that's marked as "in-progress", and put it back to "uploaded". This will show us all the original terms of the uploaded specification, allowing us to change those terms (selecting/deselecting).

# Screenshots
![mark-mapping-to-in-progress](https://user-images.githubusercontent.com/6996951/107047164-454f7780-67a6-11eb-844c-cd96a58cae1e.gif)
