### PR TITLE
Validate the schema of a configuration profile using json schema validator gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "jbuilder", "~> 2.7"
 
 gem "json_schema_tools", "~> 0.6"
 
+gem "json-schema"
+
 # Deal with sensitive data (encoding/decoding)
 gem "jwt"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     json-ld-preloaded (3.1.4)
       json-ld (~> 3.1)
       rdf (~> 3.1)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     json_schema_tools (0.6.6)
       json
     jwt (2.2.2)
@@ -461,6 +463,7 @@ DEPENDENCIES
   faker
   httparty
   jbuilder (~> 2.7)
+  json-schema
   json_schema_tools (~> 0.6)
   jwt
   linkeddata (~> 3.1)

--- a/app/models/cp_state.rb
+++ b/app/models/cp_state.rb
@@ -2,20 +2,21 @@
 
 module CpState
   class InvalidStateTransition < StandardError; end
+  class NotYetReadyForTransition < StandardError; end
   class Base
     def initialize configuration_profile
       @configuration_profile = configuration_profile
     end
 
-    def activate
+    def activate!
       raise NotImplementedError
     end
 
-    def complete
+    def complete!
       raise NotImplementedError
     end
 
-    def deactivate
+    def deactivate!
       raise NotImplementedError
     end
 
@@ -29,51 +30,47 @@ module CpState
   end
 
   class Active < Base
-    def activate
+    def activate!
       raise CpState::InvalidStateTransition, "Already activated"
     end
 
-    def complete
+    def complete!
       raise CpState::InvalidStateTransition, "Can not complete while active"
     end
 
-    def deactivate
+    def deactivate!
       @configuration_profile.transition_to! :complete
     end
   end
 
   class Complete < Base
-    def activate
+    def activate!
       @configuration_profile.transition_to! :active
       # @todo: generate all the models following the structure
     end
 
-    def complete
+    def complete!
       raise CpState::InvalidStateTransition, "Already completed"
     end
 
-    def deactivate
+    def deactivate!
       raise CpState::InvalidStateTransition, "Can not deactivate while complete"
     end
   end
 
   class Incomplete < Base
-    def activate
+    def activate!
       raise CpState::InvalidStateTransition, "Can not activate while incomplete"
     end
 
-    def complete
-      @configuration_profile.transition_to! :complete if schema_completed?
+    def complete!
+      raise CpState::NotYetReadyForTransition unless @configuration_profile.structure_complete?
+
+      @configuration_profile.transition_to! :complete
     end
 
-    def deactivate
+    def deactivate!
       raise CpState::InvalidStateTransition, "Can not deactivate while incomplete"
-    end
-
-    private
-
-    def schema_completed?
-      true # @todo: validate cp structure against json schema
     end
   end
 end

--- a/ns/complete.configurationProfile.schema.json
+++ b/ns/complete.configurationProfile.schema.json
@@ -1,0 +1,218 @@
+{
+  "type": "object",
+  "title": "Configuration Profile Schema",
+  "description": "The accepted structure for a 'configuration profile' in the DESM tool",
+  "default": {},
+  "definitions": {
+    "Agent": {
+      "type": "object",
+      "title": "The information pertaining an agent that operates the platform",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "The name for this agent to display in the profile. Desirable format: <first name><space><last name>.",
+          "examples": ["Sergio Ramos", "Lionel Messi"]
+        },
+        "email": {
+          "title": "Email address for the agent. It will serve as the username in sessions.",
+          "type": "string",
+          "pattern": "^\\S+@\\S+\\.\\S+$",
+          "format": "email",
+          "minLength": 6,
+          "maxLength": 127
+        },
+        "phone": {
+          "type": "string",
+          "title": "The american format phone number of the agent",
+          "pattern": "^\\(?([0-9]{3})\\)?[-.\\s]?([0-9]{3})[-.\\s]?([0-9]{4})$",
+          "examples": ["(123) 123-1234"]
+        },
+        "githubHandle": {
+          "type": "string",
+          "title": "The github username. Pattern is set according to the form validation messages on the 'Join Github' page",
+          "pattern": "/^[a-zd](?:[a-zd]|-(?=[a-zd])){0,38}$/i"
+        }
+      },
+      "required": ["name", "email"]
+    },
+    "DSOSchema": {
+      "type": "object",
+      "title": "A schema file that will be available to map inside the DESM tool instance for a specific standards organization.",
+      "description": "An explanation about the purpose of this instance.",
+      "required": ["name", "origin", "associatedAbstractClass"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "The name of the schema file"
+        },
+        "description": {
+          "type": "string",
+          "title": "A detailed description of the schema file. E.g. what it represents, which concepts should be expected it to contain."
+        },
+        "encodingSchema": {
+          "type": "string",
+          "title": "The encodingSchema for this schema file"
+        },
+        "version": {
+          "type": "string",
+          "title": "The version of the schema file"
+        },
+        "origin": {
+          "$id": "#/properties/standardsOrganizations/items/anyOf/0/properties/associatedSchema/items/anyOf/0/properties/origin",
+          "type": "string",
+          "title": "The origin schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+            "https://example.url.for.skos.predicates.file1,https://example.url.for.skos.predicates.file2"
+          ]
+        },
+        "associatedConceptSchemes": {
+          "title": "The associated concept schemes for this schema file",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SkosMetadata"
+          }
+        },
+        "associatedAbstractClass": {
+          "title": "The associated abstract classes for this schema file",
+          "$ref": "#/definitions/PlausibleUrl"
+        }
+      }
+    },
+    "PlausibleUrl": {
+      "anyOf": [{ "$ref": "#/definitions/SaneUrl" }, { "format": "hostname" }]
+    },
+    "SaneUrl": { "format": "uri", "pattern": "^https?://" },
+    "SkosMetadata": {
+      "type": "object",
+      "title": "Metadata about the skos file to be incorporated.",
+      "required": ["name", "origin"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "The name of the skos file."
+        },
+        "version": {
+          "type": "string",
+          "title": "The version of the skos file"
+        },
+        "description": {
+          "type": "string",
+          "title": "A description what the skos file represents."
+        },
+        "origin": {
+          "type": "array",
+          "title": "The URL/s where the file content is available",
+          "examples": [
+            "https://example.url.for.skos.predicates.file1,https://example.url.for.skos.predicates.file2"
+          ]
+        }
+      }
+    },
+    "StandardOrganization": {
+      "type": "object",
+      "title": "An organization that specifies standards for data definitions and uses the DESM tool to map from a specification to another",
+      "required": [
+        "name",
+        "dsoAdministrator",
+        "dsoAgents",
+        "associatedSchemas"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "The name of the organization",
+          "examples": ["Schema.org", "CTDL", "Credential Registry"]
+        },
+        "description": {
+          "type": "string",
+          "title": "A description that provides consistent information about the standards organization"
+        },
+        "homepageURL": {
+          "$ref": "#/definitions/PlausibleUrl",
+          "title": "The homepage URL of the standards organization",
+          "examples": ["https://example.dso.url"]
+        },
+        "standardsPage": {
+          "$ref": "#/definitions/PlausibleUrl",
+          "title": "The homepage URL of the standards organization",
+          "examples": ["https://example.dso.standards-pageurl"]
+        },
+        "dsoAdministrator": {
+          "$ref": "#/definitions/Agent"
+        },
+        "dsoAgents": {
+          "type": "array",
+          "title": "The DSO agents that will use the DESM tool to map from a specification to another",
+          "items": {
+            "$ref": "#/definitions/Agent"
+          }
+        },
+        "associatedSchemas": {
+          "type": "array",
+          "title": "The associated schema files",
+          "description": "An explanation about the purpose of this instance.",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/DSOSchema"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "standardsOrganizations",
+    "abstractClasses",
+    "mappingPredicates",
+    "profileAdministrator"
+  ],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "A name that denotes the purpose of this configuration profile. Preferably a single word",
+      "examples": ["Medical", "Education"]
+    },
+    "description": {
+      "$id": "#/properties/description",
+      "type": "string",
+      "title": "The description of the configuration profile",
+      "description": "An explanation about the purpose of this configuration profile.",
+      "default": "",
+      "examples": [
+        "This configuration profile is meant to hold mapping of specification related to the education area, with domains like student, organization, grade, etc."
+      ]
+    },
+    "createdAt": {
+      "$id": "#/properties/created_at",
+      "type": "string",
+      "title": "The date of creation for this specific configuration profile",
+      "default": "",
+      "examples": ["12-18-2020"]
+    },
+    "updatedAt": {
+      "$id": "#/properties/updated_at",
+      "type": "string",
+      "title": "The date of last modification of this specific configuration profile.",
+      "default": "",
+      "examples": ["12-18-2020"]
+    },
+    "standardsOrganizations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/StandardOrganization"
+      }
+    },
+    "abstractClasses": {
+      "$ref": "#/definitions/SkosMetadata"
+    },
+    "mappingPredicates": {
+      "$ref": "#/definitions/SkosMetadata"
+    },
+    "profileAdministrator": {
+      "$ref": "#/definitions/Agent"
+    }
+  }
+}

--- a/ns/valid.configurationProfile.schema.json
+++ b/ns/valid.configurationProfile.schema.json
@@ -2,7 +2,6 @@
   "type": "object",
   "title": "Configuration Profile Schema",
   "description": "The accepted structure for a 'configuration profile' in the DESM tool",
-  "default": {},
   "definitions": {
     "Agent": {
       "type": "object",
@@ -24,7 +23,7 @@
         "phone": {
           "type": "string",
           "title": "The american format phone number of the agent",
-          "pattern": "^(([0-9]{3}) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$",
+          "pattern": "^\\(?([0-9]{3})\\)?[-.\\s]?([0-9]{3})[-.\\s]?([0-9]{4})$",
           "examples": ["(123) 123-1234"]
         },
         "githubHandle": {
@@ -32,14 +31,12 @@
           "title": "The github username. Pattern is set according to the form validation messages on the 'Join Github' page",
           "pattern": "/^[a-zd](?:[a-zd]|-(?=[a-zd])){0,38}$/i"
         }
-      },
-      "required": ["name", "email"]
+      }
     },
     "DSOSchema": {
       "type": "object",
       "title": "A schema file that will be available to map inside the DESM tool instance for a specific standards organization.",
       "description": "An explanation about the purpose of this instance.",
-      "required": ["name"],
       "properties": {
         "name": {
           "type": "string",
@@ -76,7 +73,7 @@
         },
         "associatedAbstractClass": {
           "title": "The associated abstract classes for this schema file",
-          "$ref": "#/definitions/SkosMetadata"
+          "$ref": "#/definitions/PlausibleUrl"
         }
       }
     },
@@ -87,7 +84,6 @@
     "SkosMetadata": {
       "type": "object",
       "title": "Metadata about the skos file to be incorporated.",
-      "required": ["name", "origin"],
       "properties": {
         "name": {
           "type": "string",
@@ -108,13 +104,11 @@
             "https://example.url.for.skos.predicates.file1,https://example.url.for.skos.predicates.file2"
           ]
         }
-      },
-      "additionalProperties": true
+      }
     },
     "StandardOrganization": {
       "type": "object",
       "title": "An organization that specifies standards for data definitions and uses the DESM tool to map from a specification to another",
-      "required": ["name", "dsoAdministrator", "dsoAgents", "associatedSchema"],
       "properties": {
         "name": {
           "type": "string",
@@ -157,7 +151,6 @@
       }
     }
   },
-  "required": ["name"],
   "properties": {
     "name": {
       "$id": "#/properties/name",

--- a/spec/fixtures/complete.configuration.profile.json
+++ b/spec/fixtures/complete.configuration.profile.json
@@ -1,0 +1,71 @@
+{
+  "name": "Medical",
+  "description": "This configuration profile is meant to hold mapping of specification related to the education area, with domains like student, organization, grade, etc.",
+  "createdAt": "12-18-2020",
+  "updatedAt": "12-18-2020",
+  "standardsOrganizations": [
+    {
+      "name": "Credential Registry",
+      "description": "A description that provides consistent information about the standards organization",
+      "homepageURL": "https://example.dso.url",
+      "standardsPage": "https://example.dso.standards-pageurl",
+      "dsoAdministrator": {
+        "name": "Lionel Messi",
+        "email": "lio@messi.com",
+        "phone": "(123) 321-1234"
+      },
+      "dsoAgents": [
+        {
+          "name": "Mapper N1",
+          "email": "mapper1@credreg.com",
+          "phone": "(123) 321-1235"
+        },
+        {
+          "name": "Mapper N2",
+          "email": "mapper2@credreg.com",
+          "phone": "(123) 321-1236"
+        },
+        {
+          "name": "Mapper N3",
+          "email": "mapper3@credreg.com",
+          "phone": "(123) 321-1237"
+        }
+      ],
+      "associatedSchemas": [
+        {
+          "name": "The name of the schema file",
+          "description": "A detailed description of the schema file. E.g. what it represents, which concepts should be expected it to contain.",
+          "origin": "https://example.url.for.skos.predicates.file1",
+          "associatedAbstractClass": "http://example.org#domain1"
+        },
+        {
+          "name": "The name of the schema file",
+          "description": "A detailed description of the schema file. E.g. what it represents, which concepts should be expected it to contain.",
+          "origin": "https://example.url.for.skos.predicates.file2",
+          "associatedAbstractClass": "http://example.org#domain2"
+        }
+      ]
+    }
+  ],
+  "abstractClasses": {
+    "name": "The name of the skos file.",
+    "version": "1",
+    "description": "A description what the skos file represents.",
+    "origin": [
+      "https://example.url.for.skos.predicates.file1,https://example.url.for.skos.predicates.file2"
+    ]
+  },
+  "mappingPredicates": {
+    "name": "The name of the skos file.",
+    "version": "1",
+    "description": "A description what the skos file represents.",
+    "origin": [
+      "https://example.url.for.skos.predicates.file1,https://example.url.for.skos.predicates.file2"
+    ]
+  },
+  "profileAdministrator": {
+    "name": "Sergio Ramos",
+    "email": "sergio@ramos.com",
+    "phone": "(123) 123-1234"
+  }
+}

--- a/spec/fixtures/valid.configuration.profile.with.invalid.email.json
+++ b/spec/fixtures/valid.configuration.profile.with.invalid.email.json
@@ -1,0 +1,8 @@
+{
+  "name": "Medical",
+  "profileAdministrator": {
+    "name": "Sergio Ramos",
+    "email": "sergio@",
+    "phone": "(123) 123-1234"
+  }
+}

--- a/spec/models/configuration_profile_spec.rb
+++ b/spec/models/configuration_profile_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 describe ConfigurationProfile, type: :model do
   subject { FactoryBot.create(:configuration_profile) }
+  let(:complete_structure) {
+    JSON.parse(File.read(Rails.root.join("spec", "fixtures", "complete.configuration.profile.json")))
+  }
+  let(:valid_structure_with_invalid_email) {
+    JSON.parse(File.read(Rails.root.join("spec", "fixtures", "valid.configuration.profile.with.invalid.email.json")))
+  }
+
   it "has a valid factory" do
     expect(FactoryBot.build(:configuration_profile)).to be_valid
   end
@@ -22,13 +29,14 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be completed if validates" do
-      subject.complete
-
+      subject.structure = complete_structure
+      subject.save!
+      subject.complete!
       expect(subject.state_handler).to be_instance_of(CpState::Complete)
     end
 
     it "can not be activated" do
-      expect { subject.activate }.to raise_error CpState::InvalidStateTransition
+      expect { subject.activate! }.to raise_error CpState::InvalidStateTransition
     end
 
     it "can be exported" do
@@ -38,13 +46,15 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can not be deactivated" do
-      expect { subject.activate }.to raise_error CpState::InvalidStateTransition
+      expect { subject.activate! }.to raise_error CpState::InvalidStateTransition
     end
   end
 
   context "when it is completed" do
     before(:each) do
-      subject.complete
+      subject.structure = complete_structure
+      subject.save!
+      subject.complete!
     end
 
     it "can be removed" do
@@ -54,11 +64,12 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can not be completed again" do
-      expect { subject.complete }.to raise_error CpState::InvalidStateTransition
+      expect(subject.state_handler).to be_instance_of(CpState::Complete)
+      expect { subject.complete! }.to raise_error CpState::InvalidStateTransition
     end
 
     it "can be activated" do
-      subject.activate
+      subject.activate!
 
       expect(subject.state_handler).to be_instance_of(CpState::Active)
     end
@@ -70,14 +81,16 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can not be deactivated" do
-      expect { subject.deactivate }.to raise_error CpState::InvalidStateTransition
+      expect { subject.deactivate! }.to raise_error CpState::InvalidStateTransition
     end
   end
 
   context "when it is active" do
     before(:each) do
-      subject.complete
-      subject.activate
+      subject.structure = complete_structure
+      subject.save!
+      subject.complete!
+      subject.activate!
     end
 
     it "can be removed" do
@@ -87,11 +100,11 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can not be completed" do
-      expect { subject.complete }.to raise_error CpState::InvalidStateTransition
+      expect { subject.complete! }.to raise_error CpState::InvalidStateTransition
     end
 
     it "can not be activated again" do
-      expect { subject.activate }.to raise_error CpState::InvalidStateTransition
+      expect { subject.activate! }.to raise_error CpState::InvalidStateTransition
     end
 
     it "can be exported" do
@@ -101,9 +114,53 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be deactivated" do
-      subject.deactivate
+      subject.deactivate!
 
       expect(subject.state_handler).to be_instance_of(CpState::Complete)
+    end
+  end
+
+  context "when its structure has to be validated" do
+    it "rejects an invalid json structure for a configuration profile" do
+      invalid_object = {
+        "standardsOrganizations": 123
+      }
+      subject.structure = invalid_object
+
+      expect(subject.structure_valid?).to be_falsey
+    end
+
+    it "rejects a valid but not complete json structure for a configuration profile" do
+      valid_object = {
+        "name": "Test CP",
+        "description": "Example description for configuration profile",
+        "standardsOrganiations": [
+          {
+            "name": "Example SDO"
+          }
+        ]
+      }
+      subject.structure = valid_object
+
+      expect(subject.structure_valid?).to be_truthy
+      expect(subject.structure_complete?).to be_falsey
+    end
+
+    it "accepts as complete a complete and valid json structure for a configuration profile" do
+      subject.structure = complete_structure
+      expect(subject.structure_complete?).to be_truthy
+
+      subject.complete!
+      expect(subject.state_handler).to be_instance_of(CpState::Complete)
+    end
+
+    it "rejects a configuration profile structure with an invalid email for an agent" do
+      subject.structure = valid_structure_with_invalid_email
+
+      expect(subject.structure_complete?).to be_falsey
+      expect(subject.structure_valid?).to be_falsey
+      expect(subject.state_handler).to be_instance_of(CpState::Incomplete)
+      expect { subject.complete! }.to raise_error CpState::NotYetReadyForTransition
     end
   end
 end


### PR DESCRIPTION
### Validate the schema of a configuration profile using json schema validator gem

- Try json_schema_tools (more complicated to use)
- Try json-schemmer (1 additional step)
- Install json-schema gem
- Build 2 schemas:
  - The first to validate JSON structures and determine if it represents a valid Configuration Profile.
  - The second, to validate if a JSON structure is valid (although not complete) Configuration Profile.
- Add tests

### Move the JSON schema validation logic to the configuration profile model

In order to get the CP to know if its structure is valid or not, and having the logic to be not too extensive, the
decision was to move all the logic to the model.

### Implement validation with real complete and valid JSON Schemas for configuration profiles.

In order to validate the configuration profile structure against the JSON Schemas that defines valid and complete objects:
- Define a JSON schema for valid configuration profiles.
- Define a JSON schema for complete configuration profiles.
- Make the configuration profile able to determine whether it's valid or not by using a JSON Schema validator against its own structure.
- Redirect the configuration profile state logic to make the transition to complete by using this new configuration profile method.

### Raise error if trying to complete with incomplete structure in configuration profiles