### PR TITLE
Design list of configuration profiles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,7 +174,6 @@ a:hover {
 
 .float-over {
   position: absolute !important;
-  width: 90%;
   z-index: 5;
 }
 

--- a/app/controllers/api/v1/configuration_profile_actions_controller.rb
+++ b/app/controllers/api/v1/configuration_profile_actions_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class InvalidConfigurationProfileAction < StandardError; end
+
+class Api::V1::ConfigurationProfileActionsController < ApplicationController
+  before_action :with_instance, only: :call_action
+
+  def call_action
+    action = permitted_actions
+    @instance.send(action)
+
+    render json: @instance.reload, include: [standards_organizations: {include: :users}]
+  end
+
+  private
+
+  def with_instance
+    @instance = ConfigurationProfile.find(params[:id])
+  end
+
+  def permitted_actions
+    permitted = params.require(:configuration_profile).permit(:action)
+    action = permitted[:action].to_sym
+    raise InvalidConfigurationProfileAction unless %i[activate! complete! deactivate! export! remove!].include?(action)
+
+    action
+  end
+end

--- a/app/controllers/api/v1/configuration_profiles_controller.rb
+++ b/app/controllers/api/v1/configuration_profiles_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Api::V1::ConfigurationProfilesController < ApplicationController
+  def index
+    cps = ConfigurationProfile.order(name: :asc)
+
+    render json: cps, include: [standards_organizations: {include: :users}]
+  end
+end

--- a/app/controllers/concerns/recoverable.rb
+++ b/app/controllers/concerns/recoverable.rb
@@ -103,6 +103,11 @@ module Recoverable
         message_key: "errors.email_account_not_configured",
         status_code: :internal_server_error,
         include_original_error_message: true
+      },
+      "StandardError": {
+        message_key: "errors.general",
+        status_code: :internal_server_error,
+        include_original_error_message: true
       }
     }
   end

--- a/app/javascript/components/Routes.jsx
+++ b/app/javascript/components/Routes.jsx
@@ -18,6 +18,7 @@ import EditSpecification from "./edit-specification/EditSpecification";
 import PropertyMappingList from "./property-mapping-list/PropertyMappingList";
 import ForgotPass from "./auth/ForgotPass";
 import ResetPass from "./auth/ResetPass";
+import ConfigurationProfilesIndex from "./dashboard/configuration-profiles/ConfigurationProfilesIndex";
 
 const Routes = (props) => {
   const { handleLogin } = props;
@@ -44,9 +45,7 @@ const Routes = (props) => {
         <Route
           exact
           path={"/reset-password"}
-          render={(props) => (
-            <ResetPass {...props} handleLogin={handleLogin} />
-          )}
+          render={(props) => <ResetPass {...props} handleLogin={handleLogin} />}
         />
 
         <Route
@@ -93,6 +92,12 @@ const Routes = (props) => {
         />
 
         <ProtectedRoute exact path="/dashboard" component={MainDashboard} />
+
+        <ProtectedRoute
+          exact
+          path="/dashboard/configuration-profiles"
+          component={ConfigurationProfilesIndex}
+        />
 
         <ProtectedRoute exact path="/dashboard/users" component={UsersIndex} />
 

--- a/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
+++ b/app/javascript/components/align-and-fine-tune/AlignAndFineTune.jsx
@@ -216,7 +216,9 @@ const AlignAndFineTune = (props) => {
    * 2. The mapping term is already mapped in the backend (is one of the mapping terms mapped in DB).
    */
   const spineTermIsMapped = (spineTerm) => {
-    let alg = alignments.find((alignment) => alignment.spineTermId === spineTerm.id);
+    let alg = alignments.find(
+      (alignment) => alignment.spineTermId === spineTerm.id
+    );
     return alg.mappedTerms.length;
   };
 

--- a/app/javascript/components/auth/UserInfo.jsx
+++ b/app/javascript/components/auth/UserInfo.jsx
@@ -12,13 +12,12 @@ const UserInfo = () => {
         <React.Fragment>
           <Link to="#" className="nav-link col-on-primary">
             <i className="fas fa-user mr-2"></i>
-            {user && user.organization &&
-              (
-                <span>
-                  { user.fullname + " - " + user.organization.name }
-                </span>
-              )
-            }
+            {user && (
+              <span>
+                {_.capitalize(user.fullname) +
+                  (user.organization ? " - " + user.organization?.name : "")}
+              </span>
+            )}
           </Link>
         </React.Fragment>
       ) : (

--- a/app/javascript/components/dashboard/SideBar.jsx
+++ b/app/javascript/components/dashboard/SideBar.jsx
@@ -6,6 +6,7 @@ const SideBar = () => {
     dashboard: "/dashboard",
     users: "/dashboard/users",
     organizations: "/dashboard/organizations",
+    configuration_profiles: "/dashboard/configuration-profiles",
   };
 
   return (
@@ -16,43 +17,15 @@ const SideBar = () => {
             <ul className="flex-md-column flex-row navbar-nav w-100 justify-content-between">
               <li className="nav-item">
                 <Link
-                  to={navLinks.dashboard}
+                  to={navLinks.configuration_profiles}
                   className={`${
-                    window.location.pathname === navLinks.dashboard
+                    window.location.pathname === navLinks.configuration_profiles
                       ? "selected-dashboard-option "
                       : ""
                   }nav-link cursor-pointer col-background pl-3`}
                 >
-                  <i className="fa fa-home" aria-hidden="true"></i>
-                  <span className="pl-2">Dashboard</span>
-                </Link>
-              </li>
-
-              <li className="nav-item">
-                <Link
-                  to={navLinks.users}
-                  className={`${
-                    window.location.pathname.includes(navLinks.users)
-                      ? "selected-dashboard-option "
-                      : ""
-                  }nav-link cursor-pointer col-background pl-3`}
-                >
-                  <i className="fa fa-users" aria-hidden="true"></i>
-                  <span className="pl-2">Users</span>
-                </Link>
-              </li>
-
-              <li className="nav-item">
-                <Link
-                  to={navLinks.organizations}
-                  className={`${
-                    window.location.pathname.includes(navLinks.organizations)
-                      ? "selected-dashboard-option "
-                      : ""
-                  }nav-link cursor-pointer col-background pl-3`}
-                >
-                  <i className="fa fa-building" aria-hidden="true"></i>
-                  <span className="pl-2">Organizations</span>
+                  <i className="fa fa-cogs" aria-hidden="true"></i>
+                  <span className="pl-2">Configuration Profiles</span>
                 </Link>
               </li>
             </ul>

--- a/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
@@ -1,0 +1,103 @@
+import { downloadFile } from "../../../helpers/Export";
+import execCPAction from "../../../services/execCPAction";
+
+export class CPActionHandler {
+  constructor(
+    action,
+    needsConfirmation = false,
+    confirmationMsg = "Please confirm this action"
+  ) {
+    this.action = action;
+    this.needsConfirmation = needsConfirmation;
+    this.confirmationMsg = confirmationMsg;
+  }
+
+  async execute(configurationProfileId) {
+    return await execCPAction(configurationProfileId, `${this.action}!`);
+  }
+
+  handleResponse(configurationProfile, context) {}
+}
+
+export class Activate extends CPActionHandler {
+  constructor() {
+    super("activate", false);
+  }
+
+  handleResponse(configurationProfile, context) {
+    context.reloadCP(configurationProfile);
+  }
+}
+
+export class Complete extends CPActionHandler {
+  constructor() {
+    super(
+      "complete",
+      true,
+      "If you mark this Configuration Profile as 'completed', we will evaluate the information provided and generate all the \
+       necessary data in this DESM instance. This task includes the creation of the DSO's, agents and schemas. Please confirm \
+       to begin the process."
+    );
+  }
+}
+
+export class Deactivate extends CPActionHandler {
+  constructor() {
+    super(
+      "deactivate",
+      true,
+      "By deactivating this Configuration Profile, it will not be available to use in this DESM instance. This means that the \
+      agents belonging to it will not be able to begin or continue mapping. Please confirm."
+    );
+  }
+
+  handleResponse(configurationProfile, context) {
+    context.reloadCP(configurationProfile);
+  }
+}
+
+export class Export extends CPActionHandler {
+  constructor() {
+    super("export", false);
+  }
+
+  handleResponse(configurationProfile, context) {
+    downloadFile(
+      configurationProfile.structure,
+      `configuration-profile-${new Date().toISOString()}.json`
+    );
+  }
+}
+
+export class Remove extends CPActionHandler {
+  constructor() {
+    super(
+      "remove",
+      true,
+      "Attention! Removing this Configuration Profile implies permanently loosing all the data in it. This includes the mapping, \
+       DSO's and agents invloved, and even the metadata. Make sure you export the metadata first. Please confirm."
+    );
+  }
+}
+
+export class CPActionHandlerFactory {
+  constructor(action) {
+    if (!action) throw "No action provided";
+    this.action = action;
+  }
+
+  get() {
+    switch (this.action) {
+      case "activate":
+        return new Activate();
+      case "complete":
+        return new Complete();
+      case "deactivate":
+        return new Deactivate();
+      case "export":
+        return new Export();
+      case "remove":
+        return new Remove();
+    }
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -1,0 +1,181 @@
+import React, { Component, Fragment } from "react";
+import AlertNotice from "../../shared/AlertNotice";
+import EllipsisOptions from "../../shared/EllipsisOptions";
+import ConfirmDialog from "../../shared/ConfirmDialog";
+import { CPActionHandlerFactory } from "./CPActionHandler";
+
+const CardBody = (props) => {
+  const { configurationProfile, errors, handleOptionSelected } = props;
+
+  const cpStateOptions = {
+    active: [
+      { id: 3, name: "deactivate" },
+      { id: 4, name: "export" },
+      { id: 5, name: "remove" },
+    ],
+    complete: [
+      { id: 1, name: "activate" },
+      { id: 4, name: "export" },
+      { id: 5, name: "remove" },
+    ],
+    deactivated: [
+      { id: 1, name: "activate" },
+      { id: 4, name: "export" },
+      { id: 5, name: "remove" },
+    ],
+    incomplete: [
+      { id: 2, name: "complete" },
+      { id: 4, name: "export" },
+      { id: 5, name: "remove" },
+    ],
+  };
+
+  const stateColor = (state) => {
+    return {
+      color: stateColorsList[state],
+    };
+  };
+
+  const stateColorsList = {
+    active: "green",
+    deactivated: "grey",
+    incomplete: "red",
+    complete: "orange",
+  };
+
+  const totalAgents = () => {
+    return (
+      configurationProfile.structure?.standardsOrganizations?.reduce(
+        (sum, org) => sum + org.dsoAgents.length,
+        0
+      ) || 0
+    );
+  };
+
+  return (
+    <div className="card-body">
+      <div className="row no-gutters">
+        <div className="col-md-10">
+          <h5 className="card-title">{configurationProfile.name}</h5>
+          <p
+            className="card-text mb-0"
+            style={stateColor(configurationProfile.state)}
+          >
+            {_.capitalize(configurationProfile.state)}
+          </p>
+          <p className="card-text mb-0">{totalAgents() + " agents"}</p>
+          <p className="card-text">
+            <small className="text-muted">
+              {new Date(configurationProfile.createdAt).toLocaleString("en-US")}
+            </small>
+          </p>
+          {errors && <AlertNotice message={errors} />}
+        </div>
+        <div className="col-md-2">
+          <EllipsisOptions
+            options={cpStateOptions[configurationProfile.state]}
+            onOptionSelected={handleOptionSelected}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default class ConfigurationProfileBox extends Component {
+  state = {
+    configurationProfile: this.props.configurationProfile,
+    errors: null,
+    confirmationVisible: false,
+    actionHandler: null,
+  };
+
+  handleOptionSelected = async (option) => {
+    let handler = new CPActionHandlerFactory(option.name).get();
+
+    this.setState(
+      {
+        actionHandler: handler,
+      },
+      () => {
+        if (this.state.actionHandler.needsConfirmation) {
+          this.setState({ confirmationVisible: true });
+          return;
+        }
+
+        this.handleExecuteAction();
+      }
+    );
+  };
+
+  async handleExecuteAction() {
+    const { actionHandler, configurationProfile } = this.state;
+
+    let response = await actionHandler.execute(configurationProfile.id);
+
+    if (response.error) {
+      this.setState({ errors: response.error, confirmationVisible: false });
+      return;
+    }
+
+    actionHandler.handleResponse(response, this);
+  }
+
+  reloadCP(newCP) {
+    this.setState({
+      configurationProfile: newCP,
+      errors: null,
+      confirmationVisible: false,
+    });
+  }
+
+  render() {
+    const {
+      actionHandler,
+      configurationProfile,
+      confirmationVisible,
+      errors,
+    } = this.state;
+
+    return (
+      <Fragment>
+        {confirmationVisible && (
+          <ConfirmDialog
+            onRequestClose={() => this.setState({ confirmationVisible: false })}
+            onConfirm={() => this.handleExecuteAction()}
+            visible={confirmationVisible}
+          >
+            <h2 className="text-center">Attention!</h2>
+            <h5 className="mt-3 text-center">
+              {" "}
+              {actionHandler.confirmationMsg}
+            </h5>
+          </ConfirmDialog>
+        )}
+        <div className="card mb-3" style={{ maxWidth: "540px" }}>
+          <div className="row no-gutters">
+            <div
+              className={`col-md-4 bg-dashboard-background col-background p-5 ${
+                configurationProfile.state === "deactivated"
+                  ? "disabled-container"
+                  : ""
+              }`}
+            >
+              <i
+                className="fa fa-cogs fa-3x"
+                style={{ transform: "translateY(30%)" }}
+              ></i>
+            </div>
+            <div className="col-md-8">
+              <CardBody
+                configurationProfile={configurationProfile}
+                errors={errors}
+                handleOptionSelected={this.handleOptionSelected}
+              />
+            </div>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
@@ -1,0 +1,78 @@
+import React, { Component } from "react";
+import DashboardContainer from "../DashboardContainer";
+import { Link } from "react-router-dom";
+import AlertNotice from "../../shared/AlertNotice";
+import fetchConfigurationProfiles from "../../../services/fetchConfigurationProfiles";
+import ConfigurationProfileBox from "./ConfigurationProfileBox";
+import { camelizeKeys } from "humps";
+
+export default class ConfigurationProfilesIndex extends Component {
+  state = {
+    configurationProfiles: [],
+    errors: "",
+  };
+
+  componentDidMount() {
+    this.fetchConfigurationProfilesAPI();
+  }
+
+  dashboardPath = () => {
+    return (
+      <div className="float-right">
+        <i className="fas fa-home" />{" "}
+        <span>
+          <Link className="col-on-primary" to="/">
+            Home
+          </Link>
+        </span>{" "}
+        {`>`}{" "}
+        <span>
+          <Link className="col-on-primary" to="/dashboard">
+            Dashboard
+          </Link>
+        </span>{" "}
+        {`>`} <span>Configuration Profiles</span>
+      </div>
+    );
+  };
+
+  fetchConfigurationProfilesAPI() {
+    fetchConfigurationProfiles().then((response) => {
+      if (response.errors) {
+        this.setState({
+          errors: response.errors,
+        });
+        return;
+      }
+      this.setState({
+        configurationProfiles: response.configurationProfiles,
+      });
+    });
+  }
+
+  render() {
+    const { configurationProfiles, errors } = this.state;
+
+    return (
+      <DashboardContainer>
+        {errors && <AlertNotice message={errors} />}
+        {this.dashboardPath()}
+
+        <div className="col col-md-10 mt-5">
+          <div className="row h-50 ml-5">
+            {errors && <AlertNotice message={errors} />}
+
+            {configurationProfiles.map((cp) => {
+              return (
+                <ConfigurationProfileBox
+                  configurationProfile={camelizeKeys(cp)}
+                  key={cp.id}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </DashboardContainer>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/users/UsersIndex.jsx
+++ b/app/javascript/components/dashboard/users/UsersIndex.jsx
@@ -83,7 +83,7 @@ export default class UsersIndex extends Component {
                       <tr key={user.id}>
                         <td>{user.fullname}</td>
                         <td>{user.email}</td>
-                        <td>{user.organization.name}</td>
+                        <td>{user.organization?.name}</td>
                         <td>
                           <Link
                             to={"/dashboard/users/" + user.id}

--- a/app/javascript/components/shared/EllipsisOptions.jsx
+++ b/app/javascript/components/shared/EllipsisOptions.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Fragment } from "react";
+import { Component } from "react";
+import { FadeIn, SlideInDown } from "./Animations.jsx";
+import OutsideAlerter from "./OutsideAlerter.jsx";
+
+/**
+ * @prop {Boolean} expanded
+ * @prop {Function} onOptionSelected
+ * @prop {Array} options
+ */
+class EllipsisOptions extends Component {
+  state = {
+    expanded: this.props.expanded || false,
+  };
+
+  handleShrink = () => {
+    this.setState({ expanded: false });
+  };
+
+  handleOptionSelected = (option) => {
+    const { onOptionSelected } = this.props;
+    this.setState({ expanded: false }, () => {
+      if (onOptionSelected) {
+        onOptionSelected(option);
+      }
+    });
+  };
+
+  render() {
+    const { options } = this.props;
+    const { expanded } = this.state;
+
+    return (
+      <OutsideAlerter onOutsideAlert={() => this.handleShrink()}>
+        {expanded ? (
+          <Fragment>
+            <button className="btn float-right">
+              <i className="fas fa-ellipsis-v" />
+            </button>
+            <SlideInDown className="float-over">
+              <div className={"card"}>
+                {options.map((option) => {
+                  return (
+                    <div
+                      key={option.id}
+                      className="p-2 cursor-pointer hover-col-primary border-bottom"
+                      onClick={() => this.handleOptionSelected(option)}
+                    >
+                      {option.name}
+                    </div>
+                  );
+                })}
+              </div>
+            </SlideInDown>
+          </Fragment>
+        ) : (
+          <FadeIn>
+            <button
+              className="btn float-right"
+              onClick={() => this.setState({ expanded: true })}
+            >
+              <i className="fas fa-ellipsis-v" />
+            </button>
+          </FadeIn>
+        )}
+      </OutsideAlerter>
+    );
+  }
+}
+
+export default EllipsisOptions;

--- a/app/javascript/services/execCPAction.jsx
+++ b/app/javascript/services/execCPAction.jsx
@@ -1,0 +1,18 @@
+import { decamelizeKeys } from "humps";
+import apiRequest from "./api/apiRequest";
+
+const execCPAction = async (id, action) => {
+  let payload = decamelizeKeys({
+    configurationProfile: {
+      action: action,
+    },
+  });
+
+  return await apiRequest({
+    url: `/api/v1/configuration_profiles/${id}/action`,
+    method: "post",
+    payload,
+  });
+};
+
+export default execCPAction;

--- a/app/javascript/services/fetchConfigurationProfiles.jsx
+++ b/app/javascript/services/fetchConfigurationProfiles.jsx
@@ -1,0 +1,12 @@
+import apiRequest from "./api/apiRequest";
+
+const fetchConfigurationProfiles = async () => {
+  return await apiRequest({
+    url: "/api/v1/configuration_profiles",
+    method: "get",
+    defaultResponse: [],
+    successResponse: "configurationProfiles",
+  });
+};
+
+export default fetchConfigurationProfiles;

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -10,7 +10,7 @@ class ConfigurationProfile < ApplicationRecord
   belongs_to :abstract_classes, class_name: "DomainSet", foreign_key: :domain_set_id, optional: true
   belongs_to :mapping_predicates, class_name: "PredicateSet", foreign_key: :predicate_set_id, optional: true
   belongs_to :administrator, class_name: "User", foreign_key: :administrator_id, optional: true
-  has_many :standards_ogranizations, class_name: "Organization"
+  has_many :standards_organizations, class_name: "Organization"
   after_initialize :setup_schema_validators
 
   # The possible states
@@ -40,16 +40,16 @@ class ConfigurationProfile < ApplicationRecord
     state_handler.deactivate!
   end
 
-  def export
-    state_handler.export
+  def export!
+    state_handler.export!
   end
 
   def generate_structure
     CreateCpStructure.call({configuration_profile: self})
   end
 
-  def remove
-    state_handler.remove
+  def remove!
+    state_handler.remove!
   end
 
   def state_handler

--- a/app/models/cp_state.rb
+++ b/app/models/cp_state.rb
@@ -22,11 +22,11 @@ module CpState
       raise NotImplementedError
     end
 
-    def export
+    def export!
       @configuration_profile.structure
     end
 
-    def remove
+    def remove!
       @configuration_profile.destroy!
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8">
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
       resources :alignments, only: [:destroy, :index, :update]
+      resources :configuration_profiles, only: [:index, :create]
       resources :merged_files, only: [:create, :show]
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :predicates, only: [:index]
@@ -42,6 +43,7 @@ Rails.application.routes.draw do
       post 'merged_files/:id/filter' => 'merged_files#filter'
       get 'specifications/:id/terms' => 'terms#index'
       get 'vocabularies/:id/flat' => 'vocabularies#flat'
+      post 'configuration_profiles/:id/action' => 'configuration_profile_actions#call_action'
     end
   end
 

--- a/db/fixtures/4.users.rb
+++ b/db/fixtures/4.users.rb
@@ -10,7 +10,7 @@ User.seed(:fullname,
   fullname: "mapper 2",
   email: "mapper2@desmsolutions.org",
   password: Desm::DEFAULT_PASS,
-  organization: Organization.find(2),
+  organization: Organization.first,
   skip_sending_welcome_email: true
   },
 )

--- a/spec/interactors/create_cp_structure_spec.rb
+++ b/spec/interactors/create_cp_structure_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe CreateCpStructure, type: :interactor do
       end
 
       it "generates a structure with dso's and its respective admin, agents, schemas and concept schemes" do
-        first_org = cp.standards_ogranizations.first
+        first_org = cp.standards_organizations.first
         first_schema = Specification.for_dso(first_org).first
         second_schema = Specification.for_dso(first_org).last
         learning_method_vocab = Vocabulary.find_by_name "Learning Method"
         org_type_vocab = Vocabulary.find_by_name "Organization Type"
         assessment_method_vocab = Vocabulary.find_by_name "Assessment Method"
 
-        expect(cp.standards_ogranizations.length).to eq(1)
+        expect(cp.standards_organizations.length).to eq(1)
         expect(first_org.name).to eq("Credential Registry")
         expect(first_org.configuration_profile).to be(cp)
         expect(first_org.administrator.fullname).to eq("Lionel Messi")

--- a/spec/models/configuration_profile_spec.rb
+++ b/spec/models/configuration_profile_spec.rb
@@ -22,7 +22,7 @@ describe ConfigurationProfile, type: :model do
     expect(FactoryBot.build(:configuration_profile)).to be_valid
   end
 
-  it { should have_many(:standards_ogranizations) }
+  it { should have_many(:standards_organizations) }
 
   context "when it is incomplete" do
     it "has incomplete state at creation" do
@@ -30,11 +30,11 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "has not generated structure" do
-      expect(subject.standards_ogranizations).to be_empty
+      expect(subject.standards_organizations).to be_empty
     end
 
     it "can be removed" do
-      subject.remove
+      subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -51,7 +51,7 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be exported" do
-      exported_cp = subject.export
+      exported_cp = subject.export!
 
       expect(exported_cp).to be_equal(subject.structure)
     end
@@ -69,11 +69,11 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "has not generated structure" do
-      expect(subject.standards_ogranizations).to be_empty
+      expect(subject.standards_organizations).to be_empty
     end
 
     it "can be removed" do
-      subject.remove
+      subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -90,7 +90,7 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be exported" do
-      exported_cp = subject.export
+      exported_cp = subject.export!
 
       expect(exported_cp).to be_equal(subject.structure)
     end
@@ -109,7 +109,7 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "has a generated structure" do
-      sdos = subject.standards_ogranizations
+      sdos = subject.standards_organizations
 
       expect(sdos.length).to be(1)
       expect(sdos.first.name).to eq(complete_structure["standardsOrganizations"][0]["name"])
@@ -117,7 +117,7 @@ describe ConfigurationProfile, type: :model do
 
     # @todo remove cascade (agents, dsos, abstract classes, mapping predicates, schemas and concept schemes)
     xit "can be removed" do
-      subject.remove
+      subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -131,7 +131,7 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be exported" do
-      exported_cp = subject.export
+      exported_cp = subject.export!
 
       expect(exported_cp).to be_equal(subject.structure)
     end
@@ -152,12 +152,12 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "has a not generated structure" do
-      expect(subject.standards_ogranizations.length).to eq(1)
+      expect(subject.standards_organizations.length).to eq(1)
     end
 
     # @todo remove cascade (agents, dsos, abstract classes, mapping predicates, schemas and concept schemes)
     xit "can be removed" do
-      subject.remove
+      subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -174,7 +174,7 @@ describe ConfigurationProfile, type: :model do
     end
 
     it "can be exported" do
-      exported_cp = subject.export
+      exported_cp = subject.export!
 
       expect(exported_cp).to be_equal(subject.structure)
     end


### PR DESCRIPTION
# Description
- Remove organizations and users UI entrypoints from the dashboard menu, since now
it's going to be managed by the configuration profiles
- Design the profile box component
- Create API endpoint to list all the configuration profiles with its dsos and agents
- List the configuration profiles from the information on the API endpoint

# Diagrams
![diagram1](https://user-images.githubusercontent.com/6996951/132584974-900e898d-26d5-4f95-816c-954b3c872d8d.png)

# Screenshots
![cp-activate-deactivate](https://user-images.githubusercontent.com/6996951/132422213-285088cc-d5f6-4c85-8cac-f604d38ddd3f.gif)
