### PR TITLE
Permit cascade removal of a Configuration Profile

### DIFF
--- a/app/controllers/api/v1/configuration_profile_actions_controller.rb
+++ b/app/controllers/api/v1/configuration_profile_actions_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::ConfigurationProfileActionsController < ApplicationController
   def permitted_actions
     permitted = params.require(:configuration_profile).permit(:action)
     action = permitted[:action].to_sym
-    raise InvalidConfigurationProfileAction unless %i[activate! complete! deactivate! export! remove!].include?(action)
+    raise InvalidConfigurationProfileAction unless %i[activate! complete! deactivate! export!].include?(action)
 
     action
   end

--- a/app/controllers/api/v1/configuration_profiles_controller.rb
+++ b/app/controllers/api/v1/configuration_profiles_controller.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 class Api::V1::ConfigurationProfilesController < ApplicationController
+  before_action :with_instance, only: :destroy
+
   def index
     cps = ConfigurationProfile.order(name: :asc)
 
     render json: cps, include: [standards_organizations: {include: :users}]
+  end
+
+  def destroy
+    @instance.remove!
+
+    render json: {
+      success: true
+    }
   end
 end

--- a/app/interactors/create_agent.rb
+++ b/app/interactors/create_agent.rb
@@ -11,7 +11,7 @@ class CreateAgent
   end
 
   def call
-    agent = User.create!(user_params.merge(skip_sending_welcome_email: true))
+    agent = User.first_or_create!(user_params.merge(skip_sending_welcome_email: true))
     Assignment.create!(role: context.role, user: agent)
 
     context.agent = agent
@@ -22,8 +22,15 @@ class CreateAgent
   private
 
   def user_params
-    context.to_h
+    @agent_params = context.to_h
            .slice(:fullname, :email, :phone, :github_handle, :organization)
            .merge({password: Desm::DEFAULT_PASS})
+
+    sanitized_params
+  end
+
+  def sanitized_params
+    @agent_params.except!(:organization) if context.dso_admin
+    @agent_params
   end
 end

--- a/app/interactors/create_agent.rb
+++ b/app/interactors/create_agent.rb
@@ -11,7 +11,10 @@ class CreateAgent
   end
 
   def call
-    agent = User.first_or_create!(user_params.merge(skip_sending_welcome_email: true))
+    agent = User.find_or_initialize_by(email: user_params[:email]) do |agt|
+      agt.update!(user_params.merge({skip_sending_welcome_email: true}))
+    end
+
     Assignment.create!(role: context.role, user: agent)
 
     context.agent = agent

--- a/app/interactors/create_agent.rb
+++ b/app/interactors/create_agent.rb
@@ -23,8 +23,8 @@ class CreateAgent
 
   def user_params
     @agent_params = context.to_h
-           .slice(:fullname, :email, :phone, :github_handle, :organization)
-           .merge({password: Desm::DEFAULT_PASS})
+                           .slice(:fullname, :email, :phone, :github_handle, :organization)
+                           .merge({password: Desm::DEFAULT_PASS})
 
     sanitized_params
   end

--- a/app/interactors/create_cp_structure.rb
+++ b/app/interactors/create_cp_structure.rb
@@ -65,7 +65,7 @@ class CreateCpStructure
     @structure[:standards_organizations].each do |dso_data|
       dso_admin = create_dso_admin(dso_data[:dso_administrator])
       dso = create_dso(dso_data.merge({administrator: dso_admin}))
-      dso_admin.update!(organization: dso)
+      dso_admin.update_column(:organization_id, dso.id)
       create_dso_agents(dso, dso_data[:dso_agents])
       create_dso_schemas(dso, dso_data[:associated_schemas])
     end
@@ -79,7 +79,7 @@ class CreateCpStructure
   end
 
   def create_dso_admin dso_admin_data
-    result = CreateAgent.call(dso_admin_data.merge({role: Role.find_by_name("dso admin")}))
+    result = CreateAgent.call(dso_admin_data.merge({role: Role.find_by_name("dso admin"), dso_admin: true}))
     raise DSOAdminCreationError unless result.error.nil?
 
     result.agent

--- a/app/interactors/create_mapping_predicates.rb
+++ b/app/interactors/create_mapping_predicates.rb
@@ -15,6 +15,6 @@ class CreateMappingPredicates
     context.predicate_set = processor.create
   rescue StandardError => e
     Rails.logger.error(e.inspect)
-    context.fail!(error => e.inspect)
+    context.fail!(error: e.inspect)
   end
 end

--- a/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
@@ -76,7 +76,7 @@ export class Remove extends CPActionHandler {
       "remove",
       true,
       "Attention! Removing this Configuration Profile implies permanently loosing all the data in it. This includes the mapping, \
-       DSO's and agents invloved, and even the metadata. Make sure you export the metadata first. Please confirm."
+       DSO's and agents involved, and even the metadata. Make sure you export the metadata first. Please confirm."
     );
   }
 

--- a/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
@@ -1,5 +1,6 @@
 import { downloadFile } from "../../../helpers/Export";
 import execCPAction from "../../../services/execCPAction";
+import removeCP from "../../../services/removeCP";
 
 export class CPActionHandler {
   constructor(
@@ -16,7 +17,7 @@ export class CPActionHandler {
     return await execCPAction(configurationProfileId, `${this.action}!`);
   }
 
-  handleResponse(configurationProfile, context) {}
+  handleResponse(response, context) {}
 }
 
 export class Activate extends CPActionHandler {
@@ -24,8 +25,8 @@ export class Activate extends CPActionHandler {
     super("activate", false);
   }
 
-  handleResponse(configurationProfile, context) {
-    context.reloadCP(configurationProfile);
+  handleResponse(response, context) {
+    context.reloadCP(response);
   }
 }
 
@@ -51,8 +52,8 @@ export class Deactivate extends CPActionHandler {
     );
   }
 
-  handleResponse(configurationProfile, context) {
-    context.reloadCP(configurationProfile);
+  handleResponse(response, context) {
+    context.reloadCP(response);
   }
 }
 
@@ -61,9 +62,9 @@ export class Export extends CPActionHandler {
     super("export", false);
   }
 
-  handleResponse(configurationProfile, context) {
+  handleResponse(response, context) {
     downloadFile(
-      configurationProfile.structure,
+      response.structure,
       `configuration-profile-${new Date().toISOString()}.json`
     );
   }
@@ -77,6 +78,14 @@ export class Remove extends CPActionHandler {
       "Attention! Removing this Configuration Profile implies permanently loosing all the data in it. This includes the mapping, \
        DSO's and agents invloved, and even the metadata. Make sure you export the metadata first. Please confirm."
     );
+  }
+
+  async execute(configurationProfileId) {
+    return await removeCP(configurationProfileId);
+  }
+
+  handleResponse(response, context) {
+    context.handleRemoveResponse(response.success);
   }
 }
 

--- a/app/javascript/components/shared/EllipsisOptions.jsx
+++ b/app/javascript/components/shared/EllipsisOptions.jsx
@@ -12,6 +12,7 @@ import OutsideAlerter from "./OutsideAlerter.jsx";
 class EllipsisOptions extends Component {
   state = {
     expanded: this.props.expanded || false,
+    disabled: this.props.disabled || false,
   };
 
   handleShrink = () => {
@@ -29,13 +30,13 @@ class EllipsisOptions extends Component {
 
   render() {
     const { options } = this.props;
-    const { expanded } = this.state;
+    const { disabled, expanded } = this.state;
 
     return (
       <OutsideAlerter onOutsideAlert={() => this.handleShrink()}>
         {expanded ? (
           <Fragment>
-            <button className="btn float-right">
+            <button className="btn float-right" disabled={disabled}>
               <i className="fas fa-ellipsis-v" />
             </button>
             <SlideInDown className="float-over">

--- a/app/javascript/components/shared/Loader.jsx
+++ b/app/javascript/components/shared/Loader.jsx
@@ -3,6 +3,7 @@ import coffeeWait from "../../../assets/images/coffee-wait.gif";
 
 /**
  * Props:
+ * @prop {String} cssClass
  * @prop {String} message
  * @prop {Boolean} noPadding
  * @prop {Boolean} smallSpinner
@@ -12,10 +13,16 @@ const Loader = (props) => {
   /**
    * Elements from props
    */
-  const { message, noPadding, smallSpinner, showImage } = props;
+  const { message, noPadding, smallSpinner, showImage, cssClass } = props;
 
   return (
-    <div className={"container text-center" + (noPadding ? "" : " p-5")}>
+    <div
+      className={
+        "container text-center" +
+        (noPadding ? "" : " p-5") +
+        (` ${cssClass}` || "")
+      }
+    >
       {showImage ? (
         ""
       ) : (

--- a/app/javascript/services/removeCP.jsx
+++ b/app/javascript/services/removeCP.jsx
@@ -1,0 +1,10 @@
+import apiRequest from "./api/apiRequest";
+
+const removeCP = async (id) => {
+  return await apiRequest({
+    url: `/api/v1/configuration_profiles/${id}`,
+    method: "delete",
+  });
+};
+
+export default removeCP;

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -31,7 +31,7 @@ module Tokenable
   def generate_token
     loop do
       random_token = SecureRandom.urlsafe_base64(nil, false)
-      break random_token unless self.class.exists?(token: random_token)
+      break random_token unless self.class.default_scoped.exists?(token: random_token)
     end
   end
 end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -13,7 +13,6 @@ module Tokenable
   extend ActiveSupport::Concern
 
   included do
-    before_create :generate_token
     MIN_PASSWORD_LENGTH = begin
                             Integer(Desm::MIN_PASSWORD_LENGTH)
                           rescue TypeError

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -10,7 +10,7 @@ class ConfigurationProfile < ApplicationRecord
   belongs_to :abstract_classes, class_name: "DomainSet", foreign_key: :domain_set_id, optional: true
   belongs_to :mapping_predicates, class_name: "PredicateSet", foreign_key: :predicate_set_id, optional: true
   belongs_to :administrator, class_name: "User", foreign_key: :administrator_id, optional: true
-  has_many :standards_organizations, class_name: "Organization"
+  has_many :standards_organizations, class_name: "Organization", dependent: :destroy
   after_initialize :setup_schema_validators
   before_save :check_structure, if: :incomplete?
 

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -17,7 +17,7 @@
 ###
 class Domain < ApplicationRecord
   belongs_to :domain_set
-  belongs_to :spine, optional: true, foreign_key: "spine_id", class_name: "Specification"
+  has_one :spine, foreign_key: "domain_id", class_name: "Specification", dependent: :destroy
   validates :uri, presence: true, uniqueness: true
   validates :pref_label, presence: true
 

--- a/app/models/domain_set.rb
+++ b/app/models/domain_set.rb
@@ -15,5 +15,5 @@
 class DomainSet < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
   validates :title, presence: true
-  has_many :domains
+  has_many :domains, dependent: :destroy
 end

--- a/app/models/domain_set.rb
+++ b/app/models/domain_set.rb
@@ -15,5 +15,5 @@
 class DomainSet < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
   validates :title, presence: true
-  has_many :domains, dependent: :destroy
+  has_many :domains
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,7 @@ class Organization < ApplicationRecord
   has_many :terms, dependent: :destroy
   has_many :users
   has_many :vocabularies, dependent: :destroy
-  
+
   before_destroy :remove_agents
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,17 +4,21 @@
 # @description: Represents an organization in the application
 ###
 class Organization < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
-  belongs_to :configuration_profile
-  has_many :users, dependent: :destroy
-  has_many :vocabularies
   belongs_to :administrator, class_name: :User, foreign_key: "administrator_id"
+  belongs_to :configuration_profile
+  has_many :terms, dependent: :destroy
+  has_many :users
+  has_many :vocabularies, dependent: :destroy
+  
+  before_destroy :remove_agents
 
-  before_destroy :check_for_users, prepend: true
+  validates :name, presence: true, uniqueness: true
 
-  private
+  def remove_agents
+    agents.each(&:destroy!)
+  end
 
-  def check_for_users
-    throw(:abort) if users.any?
+  def agents
+    users.where.not(id: administrator.id)
   end
 end

--- a/app/models/predicate_set.rb
+++ b/app/models/predicate_set.rb
@@ -10,5 +10,5 @@
 class PredicateSet < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
   validates :title, presence: true
-  has_many :predicates
+  has_many :predicates, dependent: :destroy
 end

--- a/app/models/predicate_set.rb
+++ b/app/models/predicate_set.rb
@@ -10,5 +10,5 @@
 class PredicateSet < ApplicationRecord
   validates :uri, presence: true, uniqueness: true
   validates :title, presence: true
-  has_many :predicates, dependent: :destroy
+  has_many :predicates
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,18 +27,10 @@ class User < ApplicationRecord
   # RELATIONSHIPS
   ###
 
-  ###
-  # @description: The organization the user belongs to
-  ###
   belongs_to :organization, optional: true
-  ###
-  # @description: We can assign roles to the user
-  ###
   has_many :assignments, dependent: :delete_all
-  ###
-  # @description: The user's roles
-  ###
   has_many :roles, through: :assignments
+  has_many :specifications, dependent: :destroy
 
   ###
   # VALIDATIONS

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,7 @@ class User < ApplicationRecord
   end
 
   ###
-  # @description: Creates a token to rset the password of this user
+  # @description: Creates a token to reset this user's password
   ###
   def generate_password_token!
     update_columns(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,13 +14,13 @@ Rails.application.routes.draw do
   
   namespace :api do
     namespace :v1 do
+      resources :alignments, only: [:destroy, :index, :update]
       resources :alignment_vocabulary_concepts, only: [:update]
       resources :alignment_synthetic_concepts, only: [:create]
       resources :audits, only: [:index]
+      resources :configuration_profiles, only: [:index, :destroy]
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
-      resources :alignments, only: [:destroy, :index, :update]
-      resources :configuration_profiles, only: [:index, :create]
       resources :merged_files, only: [:create, :show]
       resources :organizations, only: [:index, :show, :create, :update, :destroy]
       resources :predicates, only: [:index]

--- a/db/fixtures/4.configuration_profile.rb
+++ b/db/fixtures/4.configuration_profile.rb
@@ -9,5 +9,4 @@ ConfigurationProfile.seed do |cp|
 end
 
 cp = ConfigurationProfile.first
-cp.complete!
 cp.activate!

--- a/db/migrate/20200828155236_create_domains.rb
+++ b/db/migrate/20200828155236_create_domains.rb
@@ -6,7 +6,7 @@ class CreateDomains < ActiveRecord::Migration[6.0]
       t.string :pref_label, null: false
       t.string :uri, null: false
       t.text :definition
-      t.references :domain_set, null: false, foreign_key: true
+      t.references :domain_set, null: false, foreign_key: {on_delete: :cascade}
 
       t.timestamps
     end

--- a/db/migrate/20210104135319_add_predicate_set_to_predicates.rb
+++ b/db/migrate/20210104135319_add_predicate_set_to_predicates.rb
@@ -2,6 +2,6 @@
 
 class AddPredicateSetToPredicates < ActiveRecord::Migration[6.0]
   def change
-    add_column :predicates, :predicate_set_id, :integer, column_options: {null: true}
+    add_reference :predicates, :predicate_set, foreign_key: {on_delete: :cascade}, null: :false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,7 +190,8 @@ ActiveRecord::Schema.define(version: 2021_08_21_011708) do
     t.datetime "updated_at", precision: 6, null: false
     t.float "weight", default: 0.0, null: false
     t.string "color"
-    t.integer "predicate_set_id"
+    t.bigint "predicate_set_id"
+    t.index ["predicate_set_id"], name: "index_predicates_on_predicate_set_id"
     t.index ["uri"], name: "index_predicates_on_uri", unique: true
   end
 
@@ -314,13 +315,14 @@ ActiveRecord::Schema.define(version: 2021_08_21_011708) do
   add_foreign_key "configuration_profiles", "domain_sets"
   add_foreign_key "configuration_profiles", "predicate_sets"
   add_foreign_key "configuration_profiles", "users", column: "administrator_id"
-  add_foreign_key "domains", "domain_sets"
+  add_foreign_key "domains", "domain_sets", on_delete: :cascade
   add_foreign_key "mapping_selected_terms", "mappings"
   add_foreign_key "mapping_selected_terms", "terms"
   add_foreign_key "mappings", "specifications"
   add_foreign_key "mappings", "users"
   add_foreign_key "organizations", "configuration_profiles"
   add_foreign_key "organizations", "users", column: "administrator_id"
+  add_foreign_key "predicates", "predicate_sets", on_delete: :cascade
   add_foreign_key "properties", "terms"
   add_foreign_key "specifications", "domains"
   add_foreign_key "specifications", "users"

--- a/spec/interactors/create_agent_spec.rb
+++ b/spec/interactors/create_agent_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe CreateAgent, type: :interactor do
     let(:test_role) { FactoryBot.build(:role) }
     let(:org) { FactoryBot.build(:organization) }
 
+    before(:each) do
+      Role.create!(name: "dso admin")
+    end
+
     it "rejects creation if required info isn't provided" do
       result = CreateAgent.call({github_handle: "richard0000"})
       expect(result.error).to be("Email must be present")
@@ -43,6 +47,22 @@ RSpec.describe CreateAgent, type: :interactor do
       expect(result.error).to be_nil
       expect(result.agent).to be_instance_of(User)
       expect(result.agent.organization).to be(org)
+    end
+
+    it "does not include the organization if the role is DSO Admin" do
+      dso_admin_role = Role.find_by_name "dso admin"
+      result = CreateAgent.call({
+                                  github_handle: "richard0000",
+                                  fullname: "test",
+                                  email: "test@test.com",
+                                  role: dso_admin_role,
+                                  organization: org,
+                                  dso_admin: true
+                                })
+
+      expect(result.error).to be_nil
+      expect(result.agent).to be_instance_of(User)
+      expect(result.agent.organization).to be_nil
     end
   end
 end

--- a/spec/models/configuration_profile_spec.rb
+++ b/spec/models/configuration_profile_spec.rb
@@ -112,8 +112,7 @@ describe ConfigurationProfile, type: :model do
       expect(sdos.first.name).to eq(complete_structure["standardsOrganizations"][0]["name"])
     end
 
-    # @todo remove cascade (agents, dsos, abstract classes, mapping predicates, schemas and concept schemes)
-    xit "can be removed" do
+    it "can be removed" do
       subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -151,8 +150,7 @@ describe ConfigurationProfile, type: :model do
       expect(subject.standards_organizations.length).to eq(1)
     end
 
-    # @todo remove cascade (agents, dsos, abstract classes, mapping predicates, schemas and concept schemes)
-    xit "can be removed" do
+    it "can be removed" do
       subject.remove!
 
       expect { subject.reload }.to raise_error ActiveRecord::RecordNotFound


### PR DESCRIPTION
# Description
- Make changes in the DB schema to handle cascade removal of configuration profile, organizations
users, specification, vocabularies, and terms.
- Update the UI to show a loading component when the backend is working on the removal.
- Add removal endpoint in the backend.
- Update the frontend components to interact with the new backend removal changes.
- Adapt existing tests.