### PR TITLE
Show progress to the user while activating a configuration profile

### DIFF
--- a/app/javascript/components/dashboard/configuration-profiles/ActivateProgress.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ActivateProgress.jsx
@@ -1,0 +1,114 @@
+import Modal from "react-modal";
+import React from "react";
+import { SlideInDown } from "../../shared/Animations";
+
+/**
+ * @prop {Boolean} visible
+ */
+const ActivateProgress = (props) => {
+  Modal.setAppElement("body");
+
+  const { visible } = props;
+
+  const steps = [
+    {
+      id: 1,
+      name: "Creating Configuration Profile Metadata",
+    },
+    {
+      id: 2,
+      name: "Creating Abstract Classes",
+    },
+    {
+      id: 3,
+      name: "Creating Mapping Predicates",
+    },
+    {
+      id: 4,
+      name: "Creating DSO's",
+    },
+  ];
+
+  const data = {
+    message:
+      "Please wait, we are creating all the necessary elements to get this configuration profile activated. It could take a few minutes.",
+    title: "Activating Configuration Profile",
+  };
+
+  return (
+    <Modal
+      isOpen={visible}
+      className={"fit-content-height"}
+      shouldCloseOnEsc={false}
+      shouldCloseOnOverlayClick={false}
+    >
+      <SlideInDown>
+        <div
+          className="card"
+          style={{
+            transform: "translate(50%, 25%)",
+            maxWidth: "50%",
+            borderRadius: "10px",
+          }}
+        >
+          <div className="card-header">
+            <div className="row">
+              <div className="col">
+                <h1 className="col-primary text-center">{data.title}</h1>
+              </div>
+            </div>
+          </div>
+          <div className="card-body">
+            <div className="row">
+              <div className="col">
+                <h4
+                  className="text-center mb-5"
+                  style={{ fontStyle: "italic" }}
+                >
+                  {data.message}
+                </h4>
+
+                {steps.map((step) => {
+                  return (
+                    <div
+                      className="card mb-5"
+                      key={step.id}
+                      style={{
+                        maxWidth: "50%",
+                        margin: "auto",
+                        borderRadius: "10px",
+                      }}
+                    >
+                      <div className="card-header">
+                        <div className="row">
+                          <div className="col-2">
+                            <div
+                              className="col-primary text-center"
+                              style={{
+                                position: "inherit",
+                                transform: "translate(-50%, -50%)",
+                                top: "50%",
+                                left: "50%",
+                              }}
+                            >
+                              <h6 style={{ fontWeight: "bold" }}>{step.id}</h6>
+                            </div>
+                          </div>
+                          <div className="col-10 text-center">
+                            <h5>{step.name}</h5>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </SlideInDown>
+    </Modal>
+  );
+};
+
+export default ActivateProgress;

--- a/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/CPActionHandler.jsx
@@ -13,6 +13,8 @@ export class CPActionHandler {
     this.confirmationMsg = confirmationMsg;
   }
 
+  beforeExecute() {}
+
   async execute(configurationProfileId) {
     return await execCPAction(configurationProfileId, `${this.action}!`);
   }
@@ -22,10 +24,20 @@ export class CPActionHandler {
 
 export class Activate extends CPActionHandler {
   constructor() {
-    super("activate", false);
+    super(
+      "activate",
+      true,
+      "By marking this Configuration Profile as 'Active', we will try to generate all the necessary data in this DESM instance.\
+      This task includes the creation of the DSO's, agents and schemas. Please confirm to begin the process."
+    );
+  }
+
+  beforeExecute(context) {
+    context.showActivatingProgress();
   }
 
   handleResponse(response, context) {
+    context.hideActivatingProgress();
     context.reloadCP(response);
   }
 }
@@ -35,9 +47,8 @@ export class Complete extends CPActionHandler {
     super(
       "complete",
       true,
-      "If you mark this Configuration Profile as 'completed', we will evaluate the information provided and generate all the \
-       necessary data in this DESM instance. This task includes the creation of the DSO's, agents and schemas. Please confirm \
-       to begin the process."
+      "If you mark this Configuration Profile as 'completed', we will evaluate the information provided. If it fails, please \
+      review the information is complete."
     );
   }
 }

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -4,6 +4,7 @@ import AlertNotice from "../../shared/AlertNotice";
 import EllipsisOptions from "../../shared/EllipsisOptions";
 import ConfirmDialog from "../../shared/ConfirmDialog";
 import { CPActionHandlerFactory } from "./CPActionHandler";
+import ActivateProgress from "./ActivateProgress";
 
 const CardBody = (props) => {
   const {
@@ -93,6 +94,7 @@ const CardBody = (props) => {
 export default class ConfigurationProfileBox extends Component {
   state = {
     actionHandler: null,
+    activating: false,
     configurationProfile: this.props.configurationProfile,
     confirmationVisible: false,
     errors: null,
@@ -121,11 +123,16 @@ export default class ConfigurationProfileBox extends Component {
   async handleExecuteAction() {
     const { actionHandler, configurationProfile } = this.state;
     this.setState({ processing: true, confirmationVisible: false });
+    actionHandler.beforeExecute(this);
+    let response;
 
-    let response = await actionHandler.execute(configurationProfile.id);
-
+    response = await actionHandler.execute(configurationProfile.id);
     if (response.error) {
-      this.setState({ errors: response.error, processing: false });
+      this.setState({
+        errors: response.error,
+        processing: false,
+        activating: false,
+      });
       return;
     }
 
@@ -144,8 +151,17 @@ export default class ConfigurationProfileBox extends Component {
     if (success) this.setState({ removed: true });
   }
 
+  showActivatingProgress() {
+    this.setState({ activating: true });
+  }
+
+  hideActivatingProgress() {
+    this.setState({ activating: false });
+  }
+
   render() {
     const {
+      activating,
       actionHandler,
       configurationProfile,
       confirmationVisible,
@@ -169,6 +185,7 @@ export default class ConfigurationProfileBox extends Component {
             </h5>
           </ConfirmDialog>
         )}
+        <ActivateProgress visible={activating} />
         {removed ? (
           ""
         ) : (

--- a/app/javascript/components/shared/ConfirmDialog.jsx
+++ b/app/javascript/components/shared/ConfirmDialog.jsx
@@ -1,6 +1,6 @@
 import Modal from "react-modal";
 import React from "react";
-import { FadeIn, SlideInDown } from "./Animations.jsx";
+import { SlideInDown } from "./Animations.jsx";
 
 /**
  * Props:

--- a/app/services/processors/domains.rb
+++ b/app/services/processors/domains.rb
@@ -53,12 +53,13 @@ module Processors
 
         parser = Parsers::JsonLd::Node.new(domain)
 
-        Domain.first_or_create!({
-                                  uri: parser.read!("id"),
-                                  pref_label: parser.read!("prefLabel"),
-                                  definition: parser.read!("definition"),
-                                  domain_set: @domain_set
-                                })
+        Domain.find_or_initialize_by(uri: parser.read!("id")) do |d|
+          d.update!(
+            pref_label: parser.read!("prefLabel"),
+            definition: parser.read!("definition"),
+            domain_set: @domain_set
+          )
+        end
       end
     end
   end

--- a/app/services/processors/domains.rb
+++ b/app/services/processors/domains.rb
@@ -53,7 +53,7 @@ module Processors
 
         parser = Parsers::JsonLd::Node.new(domain)
 
-        Domain.create!({
+        Domain.first_or_create!({
                          uri: parser.read!("id"),
                          pref_label: parser.read!("prefLabel"),
                          definition: parser.read!("definition"),

--- a/app/services/processors/domains.rb
+++ b/app/services/processors/domains.rb
@@ -54,11 +54,11 @@ module Processors
         parser = Parsers::JsonLd::Node.new(domain)
 
         Domain.first_or_create!({
-                         uri: parser.read!("id"),
-                         pref_label: parser.read!("prefLabel"),
-                         definition: parser.read!("definition"),
-                         domain_set: @domain_set
-                       })
+                                  uri: parser.read!("id"),
+                                  pref_label: parser.read!("prefLabel"),
+                                  definition: parser.read!("definition"),
+                                  domain_set: @domain_set
+                                })
       end
     end
   end

--- a/app/services/processors/predicates.rb
+++ b/app/services/processors/predicates.rb
@@ -57,13 +57,14 @@ module Processors
         # The concept scheme is processed, let's start with the proper predicates
         next unless valid_predicate(predicate, parser)
 
-        Predicate.first_or_create!({
-                                     definition: parser.read!("definition"),
-                                     pref_label: parser.read!("prefLabel"),
-                                     uri: parser.read!("id"),
-                                     weight: parser.read!("weight"),
-                                     predicate_set: @predicate_set
-                                   })
+        Predicate.find_or_initialize_by(uri: parser.read!("id")) do |p|
+          p.update!({
+                      definition: parser.read!("definition"),
+                      pref_label: parser.read!("prefLabel"),
+                      weight: parser.read!("weight"),
+                      predicate_set: @predicate_set
+                    })
+        end
       end
     end
 

--- a/app/services/processors/predicates.rb
+++ b/app/services/processors/predicates.rb
@@ -58,12 +58,12 @@ module Processors
         next unless valid_predicate(predicate, parser)
 
         Predicate.first_or_create!({
-                            definition: parser.read!("definition"),
-                            pref_label: parser.read!("prefLabel"),
-                            uri: parser.read!("id"),
-                            weight: parser.read!("weight"),
-                            predicate_set: @predicate_set
-                          })
+                                     definition: parser.read!("definition"),
+                                     pref_label: parser.read!("prefLabel"),
+                                     uri: parser.read!("id"),
+                                     weight: parser.read!("weight"),
+                                     predicate_set: @predicate_set
+                                   })
       end
     end
 

--- a/app/services/processors/predicates.rb
+++ b/app/services/processors/predicates.rb
@@ -57,7 +57,7 @@ module Processors
         # The concept scheme is processed, let's start with the proper predicates
         next unless valid_predicate(predicate, parser)
 
-        Predicate.create!({
+        Predicate.first_or_create!({
                             definition: parser.read!("definition"),
                             pref_label: parser.read!("prefLabel"),
                             uri: parser.read!("id"),


### PR DESCRIPTION
# Description
To activate a configuration profile, if its state is 'complete', implies creating all the related data,
like DSO's, agents, schemes and more. So depending on the amount of data specified, it may take a few minutes.
Now we show a progress locked window to the user when performing this task.

# Screenshots
![Screenshot from 2021-09-13 19-13-42](https://user-images.githubusercontent.com/6996951/133169579-82ae145c-56cd-49ba-8045-f7b1509f86a6.png)
