### PR TITLE
Feature/92 create new configuration profile option

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -287,6 +287,10 @@ a:hover {
   margin-right: 10% !important;
 }
 
+.cp-step-row {
+  margin-bottom: 60%;
+}
+
 .border-color-dashboard {
   border: 2px solid $dashboard-background-color-highlight;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -111,6 +111,10 @@ a:hover {
   background-color: $dashboard-background-color-highlight !important;
 }
 
+.col-dashboard-highlight {
+  color: $dashboard-background-color-highlight !important;
+}
+
 .bg-col-primary {
   background-color: $primary-color !important;
 }
@@ -272,6 +276,19 @@ a:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   max-height: 40px;
+}
+
+.border-top-dashboard-highlight {
+  border-top: 3px solid $dashboard-background-color-highlight !important;
+}
+
+.cp-container {
+  margin-left: 10% !important;
+  margin-right: 10% !important;
+}
+
+.border-color-dashboard {
+  border: 2px solid $dashboard-background-color-highlight;
 }
 
 /* Mobile */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -268,6 +268,12 @@ a:hover {
   box-shadow: 4px 8px 5px -7px $on-primary-light;
 }
 
+.box-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 40px;
+}
+
 /* Mobile */
 
 @media (max-width: 768px) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -107,6 +107,10 @@ a:hover {
   background-color: $dashboard-background-color !important;
 }
 
+.bg-dashboard-background-highlight {
+  background-color: $dashboard-background-color-highlight !important;
+}
+
 .bg-col-primary {
   background-color: $primary-color !important;
 }

--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -10,3 +10,4 @@ $foreground-color: #e2e2e2;
 $success-color: green;
 $dashboard-background-color: #132639;
 $dashboard-background-color-light: #efefef;
+$dashboard-background-color-highlight: #2d9bf0;

--- a/app/controllers/api/v1/configuration_profiles_controller.rb
+++ b/app/controllers/api/v1/configuration_profiles_controller.rb
@@ -2,6 +2,16 @@
 
 class Api::V1::ConfigurationProfilesController < ApplicationController
   before_action :with_instance, only: :destroy
+  DEFAULT_CP_NAME = "Desm CP - #{DateTime.now.rfc3339}"
+
+  def create
+    cp = ConfigurationProfile.create!(creation_params)
+
+    render json: {
+      success: true,
+      configuration_profile: cp
+    }
+  end
 
   def index
     cps = ConfigurationProfile.order(name: :asc)
@@ -15,5 +25,15 @@ class Api::V1::ConfigurationProfilesController < ApplicationController
     render json: {
       success: true
     }
+  end
+
+  private
+
+  def creation_params
+    permitted_params.merge({name: DEFAULT_CP_NAME, administrator: @current_user})
+  end
+
+  def permitted_params
+    params.require(:configuration_profile).permit(:name, :description, :structure)
   end
 end

--- a/app/controllers/api/v1/configuration_profiles_controller.rb
+++ b/app/controllers/api/v1/configuration_profiles_controller.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 class Api::V1::ConfigurationProfilesController < ApplicationController
-  before_action :with_instance, only: :destroy
+  before_action :with_instance, only: %i[destroy show]
   DEFAULT_CP_NAME = "Desm CP - #{DateTime.now.rfc3339}"
 
   def create
     cp = ConfigurationProfile.create!(creation_params)
 
-    render json: {
-      success: true,
-      configuration_profile: cp
-    }
+    render json: cp
   end
 
   def index
@@ -25,6 +22,10 @@ class Api::V1::ConfigurationProfilesController < ApplicationController
     render json: {
       success: true
     }
+  end
+
+  def show
+    render json: @instance, include: [standards_organizations: {include: :users}]
   end
 
   private

--- a/app/javascript/actions/configurationProfiles.jsx
+++ b/app/javascript/actions/configurationProfiles.jsx
@@ -1,0 +1,6 @@
+export const setStep = (step) => {
+  return {
+    type: "SET_STEP",
+    payload: step,
+  };
+};

--- a/app/javascript/actions/configurationProfiles.jsx
+++ b/app/javascript/actions/configurationProfiles.jsx
@@ -4,3 +4,10 @@ export const setStep = (step) => {
     payload: step,
   };
 };
+
+export const setCurrentConfigurationProfile = (configurationProfile) => {
+  return {
+    type: "SET_CURRENT_CP",
+    payload: configurationProfile,
+  };
+};

--- a/app/javascript/components/Routes.jsx
+++ b/app/javascript/components/Routes.jsx
@@ -19,6 +19,7 @@ import PropertyMappingList from "./property-mapping-list/PropertyMappingList";
 import ForgotPass from "./auth/ForgotPass";
 import ResetPass from "./auth/ResetPass";
 import ConfigurationProfilesIndex from "./dashboard/configuration-profiles/ConfigurationProfilesIndex";
+import EditConfigurationProfile from "./dashboard/configuration-profiles/edit/EditConfigurationProfile";
 
 const Routes = (props) => {
   const { handleLogin } = props;
@@ -97,6 +98,12 @@ const Routes = (props) => {
           exact
           path="/dashboard/configuration-profiles"
           component={ConfigurationProfilesIndex}
+        />
+
+        <ProtectedRoute
+          exact
+          path="/dashboard/configuration-profiles/:id"
+          component={EditConfigurationProfile}
         />
 
         <ProtectedRoute exact path="/dashboard/users" component={UsersIndex} />

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -5,7 +5,29 @@ import EllipsisOptions from "../../shared/EllipsisOptions";
 import ConfirmDialog from "../../shared/ConfirmDialog";
 import { CPActionHandlerFactory } from "./CPActionHandler";
 import ActivateProgress from "./ActivateProgress";
-import { CPBoxContainer } from "./ConfigurationProfilesIndex";
+
+export const CPBoxContainer = (props) => {
+  const { children, iconClass, sideBoxClass } = props;
+  const action = props.action || (() => {});
+
+  return (
+    <div className="card mb-3 mr-3" style={{ width: "350px" }}>
+      <div className="row no-gutters" style={{ height: "130px" }}>
+        <div
+          className={"col-md-4 p-5 cursor-pointer " + (sideBoxClass || "")}
+          style={{ height: "130px" }}
+          onClick={action}
+        >
+          <i
+            className={`fas ${iconClass} fa-3x`}
+            style={{ transform: "translateY(20%) translateX(-5%)" }}
+          ></i>
+        </div>
+        <div className="col-md-8">{children}</div>
+      </div>
+    </div>
+  );
+};
 
 const CardBody = (props) => {
   const {
@@ -64,7 +86,7 @@ const CardBody = (props) => {
     <div className="card-body">
       <div className="row no-gutters">
         <div className="col-md-10">
-          <h5 className="card-title">{configurationProfile.name}</h5>
+          <h5 className="card-title box-title">{configurationProfile.name}</h5>
           {processing && <Loader noPadding={true} cssClass={"float-over"} />}
           <p
             className="card-text mb-0"

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -5,6 +5,7 @@ import EllipsisOptions from "../../shared/EllipsisOptions";
 import ConfirmDialog from "../../shared/ConfirmDialog";
 import { CPActionHandlerFactory } from "./CPActionHandler";
 import ActivateProgress from "./ActivateProgress";
+import { CPBoxContainer } from "./ConfigurationProfilesIndex";
 
 const CardBody = (props) => {
   const {
@@ -189,30 +190,21 @@ export default class ConfigurationProfileBox extends Component {
         {removed ? (
           ""
         ) : (
-          <div className="card mb-3" style={{ maxWidth: "540px" }}>
-            <div className="row no-gutters">
-              <div
-                className={`col-md-4 bg-dashboard-background col-background p-5 ${
-                  configurationProfile.state === "deactivated" || processing
-                    ? "disabled-container"
-                    : ""
-                }`}
-              >
-                <i
-                  className="fas fa-cogs fa-3x"
-                  style={{ transform: "translateY(30%) translateX(10%)" }}
-                ></i>
-              </div>
-              <div className="col-md-8">
-                <CardBody
-                  configurationProfile={configurationProfile}
-                  errors={errors}
-                  handleOptionSelected={this.handleOptionSelected}
-                  processing={processing}
-                />
-              </div>
-            </div>
-          </div>
+          <CPBoxContainer
+            sideBoxClass={`bg-dashboard-background col-background p-5 ${
+              configurationProfile.state === "deactivated" || processing
+                ? "disabled-container"
+                : ""
+            }`}
+            iconClass="fa-cogs"
+          >
+            <CardBody
+              configurationProfile={configurationProfile}
+              errors={errors}
+              handleOptionSelected={this.handleOptionSelected}
+              processing={processing}
+            />
+          </CPBoxContainer>
         )}
       </Fragment>
     );

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -5,10 +5,19 @@ import EllipsisOptions from "../../shared/EllipsisOptions";
 import ConfirmDialog from "../../shared/ConfirmDialog";
 import { CPActionHandlerFactory } from "./CPActionHandler";
 import ActivateProgress from "./ActivateProgress";
+import { Link } from "react-router-dom";
 
 export const CPBoxContainer = (props) => {
-  const { children, iconClass, sideBoxClass } = props;
+  const { children, iconClass, linkTo, sideBoxClass } = props;
   const action = props.action || (() => {});
+  const renderIcon = () => {
+    return (
+      <i
+        className={`fas ${iconClass} fa-3x`}
+        style={{ transform: "translateY(20%) translateX(-5%)" }}
+      ></i>
+    );
+  };
 
   return (
     <div className="card mb-3 mr-3" style={{ width: "350px" }}>
@@ -18,10 +27,13 @@ export const CPBoxContainer = (props) => {
           style={{ height: "130px" }}
           onClick={action}
         >
-          <i
-            className={`fas ${iconClass} fa-3x`}
-            style={{ transform: "translateY(20%) translateX(-5%)" }}
-          ></i>
+          {linkTo ? (
+            <Link to={linkTo} className="col-background">
+              {renderIcon()}
+            </Link>
+          ) : (
+            renderIcon()
+          )}
         </div>
         <div className="col-md-8">{children}</div>
       </div>
@@ -219,6 +231,7 @@ export default class ConfigurationProfileBox extends Component {
                 : ""
             }`}
             iconClass="fa-cogs"
+            linkTo={`/dashboard/configuration-profiles/${configurationProfile.id}`}
           >
             <CardBody
               configurationProfile={configurationProfile}

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -6,6 +6,7 @@ import ConfirmDialog from "../../shared/ConfirmDialog";
 import { CPActionHandlerFactory } from "./CPActionHandler";
 import ActivateProgress from "./ActivateProgress";
 import { Link } from "react-router-dom";
+import { stateStyle } from "./utils";
 
 export const CPBoxContainer = (props) => {
   const { children, iconClass, linkTo, sideBoxClass } = props;
@@ -73,19 +74,6 @@ const CardBody = (props) => {
     ],
   };
 
-  const stateColor = (state) => {
-    return {
-      color: stateColorsList[state],
-    };
-  };
-
-  const stateColorsList = {
-    active: "green",
-    deactivated: "grey",
-    incomplete: "red",
-    complete: "orange",
-  };
-
   const totalAgents = () => {
     return (
       configurationProfile.structure?.standardsOrganizations?.reduce(
@@ -103,7 +91,7 @@ const CardBody = (props) => {
           {processing && <Loader noPadding={true} cssClass={"float-over"} />}
           <p
             className="card-text mb-0"
-            style={stateColor(configurationProfile.state)}
+            style={stateStyle(configurationProfile.state)}
           >
             {_.capitalize(configurationProfile.state)}
           </p>

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfileBox.jsx
@@ -10,6 +10,7 @@ import { Link } from "react-router-dom";
 export const CPBoxContainer = (props) => {
   const { children, iconClass, linkTo, sideBoxClass } = props;
   const action = props.action || (() => {});
+
   const renderIcon = () => {
     return (
       <i

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
@@ -103,6 +103,10 @@ export default class ConfigurationProfilesIndex extends Component {
         });
         return;
       }
+
+      this.props.history.push(
+        `/dashboard/configuration-profiles/${response.configurationProfile.id}`
+      );
     });
   };
 
@@ -111,13 +115,11 @@ export default class ConfigurationProfilesIndex extends Component {
 
     return (
       <DashboardContainer>
-        {errors && <AlertNotice message={errors} />}
         {this.dashboardPath()}
 
         <div className="col mt-5">
+          {errors && <AlertNotice message={errors} />}
           <div className="row h-50 ml-5">
-            {errors && <AlertNotice message={errors} />}
-
             {configurationProfiles.map((cp) => {
               return (
                 <ConfigurationProfileBox

--- a/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/ConfigurationProfilesIndex.jsx
@@ -6,6 +6,45 @@ import fetchConfigurationProfiles from "../../../services/fetchConfigurationProf
 import ConfigurationProfileBox from "./ConfigurationProfileBox";
 import { camelizeKeys } from "humps";
 
+export const CPBoxContainer = (props) => {
+  const { children, iconClass, sideBoxClass } = props;
+  const action = props.action || (() => {});
+
+  return (
+    <div className="card mb-3 mr-3" style={{ maxWidth: "540px" }}>
+      <div className="row no-gutters" style={{ height: "130px" }}>
+        <div
+          className={"col-md-4 p-5 cursor-pointer " + (sideBoxClass || "")}
+          style={{ height: "130px" }}
+          onClick={action}
+        >
+          <i
+            className={`fas ${iconClass} fa-3x`}
+            style={{ transform: "translateY(30%) translateX(10%)" }}
+          ></i>
+        </div>
+        <div className="col-md-8">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+const NewConfigurationProfile = () => {
+  const handleCreate = () => {
+    console.log("Creating a new Configuration Profile");
+  };
+
+  return (
+    <CPBoxContainer
+      iconClass="fa-plus"
+      sideBoxClass="bg-dashboard-background-highlight col-background"
+      action={handleCreate}
+    >
+      <h5 className="m-5">Add a Configuration Profile</h5>
+    </CPBoxContainer>
+  );
+};
+
 export default class ConfigurationProfilesIndex extends Component {
   state = {
     configurationProfiles: [],
@@ -70,6 +109,8 @@ export default class ConfigurationProfilesIndex extends Component {
                 />
               );
             })}
+
+            <NewConfigurationProfile />
           </div>
         </div>
       </DashboardContainer>

--- a/app/javascript/components/dashboard/configuration-profiles/edit/AbstractClasses.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/AbstractClasses.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from "react";
+
+export default class AbstractClasses extends Component {
+  render() {
+    return (
+      <div className="card">
+        <div className="card-header">Abstract Classes</div>
+      </div>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/DSOMetaData.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/DSOMetaData.jsx
@@ -44,7 +44,6 @@ const DSOMetaData = () => {
             className="form-control input-lg"
             name="createdAt"
             value={configurationProfile.createdAt}
-            autoFocus
             required
           />
         </div>
@@ -58,7 +57,6 @@ const DSOMetaData = () => {
             className="form-control input-lg"
             name="updatedAt"
             value={configurationProfile.updatedAt}
-            autoFocus
             required
           />
         </div>

--- a/app/javascript/components/dashboard/configuration-profiles/edit/DSOMetaData.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/DSOMetaData.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { useSelector } from "react-redux";
+
+const DSOMetaData = () => {
+  const configurationProfile = useSelector((state) => state.currentCP);
+
+  return (
+    <div className="col">
+      <div className="mt-5">
+        <label>
+          Profile Name
+          <span className="text-danger">*</span>
+        </label>
+        <div className="input-group input-group">
+          <input
+            type="text"
+            className="form-control input-lg"
+            name="name"
+            placeholder="Give a descriptive name for the configuration profile"
+            value={configurationProfile.name}
+            autoFocus
+            required
+          />
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <label>Profile Description</label>
+        <div className="input-group input-group">
+          <textarea
+            className="form-control input-lg"
+            name="description"
+            placeholder="A description that provides consistent information about the standards organization"
+            value={configurationProfile.description}
+          />
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <label>Date Created</label>
+        <div className="input-group input-group">
+          <input
+            type="date"
+            className="form-control input-lg"
+            name="createdAt"
+            value={configurationProfile.createdAt}
+            autoFocus
+            required
+          />
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <label>Date Last Modified</label>
+        <div className="input-group input-group">
+          <input
+            type="date"
+            className="form-control input-lg"
+            name="updatedAt"
+            value={configurationProfile.updatedAt}
+            autoFocus
+            required
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DSOMetaData;

--- a/app/javascript/components/dashboard/configuration-profiles/edit/DSOsInfo.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/DSOsInfo.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from "react";
+
+export default class DSOsInfo extends Component {
+  render() {
+    return (
+      <div className="card">
+        <div className="card-header">DSO's Information</div>
+      </div>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -11,17 +11,15 @@ import MappingPredicates from "./MappingPredicates";
 import AbstractClasses from "./AbstractClasses";
 import DSOsInfo from "./DSOsInfo";
 import { useDispatch, useSelector } from "react-redux";
-import { setCurrentConfigurationProfile } from "../../../../actions/configurationProfiles";
+import {
+  setCurrentConfigurationProfile,
+  setStep,
+} from "../../../../actions/configurationProfiles";
 import { camelizeKeys } from "humps";
 
 const EditConfigurationProfile = (props) => {
   const [errors, setErrors] = useState("");
   const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetchCP();
-  }, []);
-
   const configurationProfile = useSelector((state) => state.currentCP);
 
   const dashboardPath = () => {
@@ -71,6 +69,11 @@ const EditConfigurationProfile = (props) => {
       setLoading(false);
     });
   };
+
+  useEffect(() => {
+    dispatch(setStep(1));
+    fetchCP();
+  }, []);
 
   return (
     <DashboardContainer>

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -34,7 +34,6 @@ export default class EditConfigurationProfile extends Component {
   };
 
   componentDidMount() {
-    console.log("mounted");
     this.fetchCP();
   }
 

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
+import fetchConfigurationProfile from "../../../../services/fetchConfigurationProfile";
+import AlertNotice from "../../../shared/AlertNotice";
+import Loader from "../../../shared/Loader";
+import DashboardContainer from "../../DashboardContainer";
+
+export default class EditConfigurationProfile extends Component {
+  state = {
+    configurationProfile: {},
+    configurationProfileId: this.props.match.params.id,
+    errors: "",
+    loading: true,
+  };
+
+  fetchCP = () => {
+    const { configurationProfileId } = this.state;
+
+    fetchConfigurationProfile(configurationProfileId).then((response) => {
+      if (response.error) {
+        this.setState({
+          errors: response.error,
+          loading: false,
+        });
+        return;
+      }
+
+      this.setState({
+        configurationProfile: response.configurationProfile,
+        loading: false,
+      });
+    });
+  };
+
+  componentDidMount() {
+    console.log("mounted");
+    this.fetchCP();
+  }
+
+  dashboardPath = () => {
+    return (
+      <div className="float-right">
+        <i className="fas fa-home" />{" "}
+        <span>
+          <Link className="col-on-primary" to="/">
+            Home
+          </Link>
+        </span>{" "}
+        {`>`}{" "}
+        <span>
+          <Link className="col-on-primary" to="/dashboard">
+            Dashboard
+          </Link>
+        </span>{" "}
+        {`>`}{" "}
+        <span>
+          <Link
+            className="col-on-primary"
+            to="/dashboard/configuration-profiles"
+          >
+            Configuration Profiles
+          </Link>
+        </span>
+        <span>Edit</span>
+      </div>
+    );
+  };
+
+  render() {
+    const { configurationProfile, errors, loading } = this.state;
+
+    return (
+      <DashboardContainer>
+        {this.dashboardPath()}
+
+        {loading ? (
+          <Loader />
+        ) : (
+          <div className="col mt-5">
+            {errors && <AlertNotice message={errors} />}
+            <div className="row h-50 ml-5">
+              <h1>{`Configuration Profile ${configurationProfile.name}`}</h1>
+            </div>
+          </div>
+        )}
+      </DashboardContainer>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -21,6 +21,7 @@ const EditConfigurationProfile = (props) => {
   const [errors, setErrors] = useState("");
   const [loading, setLoading] = useState(true);
   const configurationProfile = useSelector((state) => state.currentCP);
+  const currentStep = useSelector((state) => state.cpStep);
 
   const dashboardPath = () => {
     return (
@@ -93,9 +94,9 @@ const EditConfigurationProfile = (props) => {
               </div>
             </div>
             <div className="col-9">
-              <div className="card border-top-dashboard-highlight">
-                <div className="card-body">
-                  <div className="row justify-content-center h-100">
+              <div className="card border-top-dashboard-highlight h-100">
+                <div className="card-body d-flex flex-column">
+                  <div className="row justify-content-center">
                     <div className="col-6">
                       <h3 className="float-left">
                         {_.capitalize(configurationProfile.name)}
@@ -110,8 +111,32 @@ const EditConfigurationProfile = (props) => {
                       </p>
                     </div>
                   </div>
-                  <div className="row justify-content-center h-100">
+                  <div className="row justify-content-center">
                     <PageStepRenderer />
+                  </div>
+                  <div className="row mt-auto ml-auto">
+                    {currentStep !== 1 && (
+                      <button
+                        className="btn btn-dark mr-3"
+                        style={{ width: "10rem" }}
+                        onClick={() => {
+                          dispatch(setStep(currentStep - 1));
+                        }}
+                      >
+                        Previous
+                      </button>
+                    )}
+                    {currentStep !== 4 && (
+                      <button
+                        className="btn btn-dark mr-3"
+                        style={{ width: "10rem" }}
+                        onClick={() => {
+                          dispatch(setStep(currentStep + 1));
+                        }}
+                      >
+                        Next
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/EditConfigurationProfile.jsx
@@ -4,6 +4,7 @@ import fetchConfigurationProfile from "../../../../services/fetchConfigurationPr
 import AlertNotice from "../../../shared/AlertNotice";
 import Loader from "../../../shared/Loader";
 import DashboardContainer from "../../DashboardContainer";
+import StepsAside from "./StepsAside";
 
 export default class EditConfigurationProfile extends Component {
   state = {
@@ -60,8 +61,8 @@ export default class EditConfigurationProfile extends Component {
           >
             Configuration Profiles
           </Link>
-        </span>
-        <span>Edit</span>
+        </span>{" "}
+        {`>`} <span>Edit</span>
       </div>
     );
   };
@@ -78,8 +79,28 @@ export default class EditConfigurationProfile extends Component {
         ) : (
           <div className="col mt-5">
             {errors && <AlertNotice message={errors} />}
-            <div className="row h-50 ml-5">
-              <h1>{`Configuration Profile ${configurationProfile.name}`}</h1>
+            <div className="row cp-container justify-content-center h-100">
+              <div className="col-3">
+                <StepsAside />
+              </div>
+              <div className="col-9">
+                <div className="card border-top-dashboard-highlight">
+                  <div className="card-body">
+                    <div className="row">
+                      <div className="col-6">
+                        <h3 className="float-left">
+                          {_.capitalize(configurationProfile.name)}
+                        </h3>
+                      </div>
+                      <div className="col-6">
+                        <p className="float-right col-primary">
+                          {_.capitalize(configurationProfile.state)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         )}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/MappingPredicates.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/MappingPredicates.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from "react";
+
+export default class MappingPredicates extends Component {
+  render() {
+    return (
+      <div className="card">
+        <div className="card-header">Mapping Predicates</div>
+      </div>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
@@ -1,0 +1,47 @@
+import React, { Component, Fragment } from "react";
+
+export default class StepsAside extends Component {
+  steps = [
+    {
+      number: 1,
+      description: "General data about the configuration profile",
+      active: true,
+    },
+    {
+      number: 2,
+      description: "Select the mapping predicates",
+    },
+    {
+      number: 3,
+      description: "Select the abstract classes",
+    },
+    {
+      number: 4,
+      description: "DSO's information",
+    },
+  ];
+
+  render() {
+    return (
+      <Fragment>
+        {this.steps.map((step) => {
+          return (
+            <div className="row justify-content-center h-100">
+              <div className="col-8">{step.description}</div>
+              <div
+                className={`col-4 rounded-circle ${
+                  step.active
+                    ? "bg-dashboard-background-highlight col-background"
+                    : "border-color-dashboard col-dashboard-highlight"
+                } p-3 text-center`}
+                style={{ maxWidth: "50px", height: "50px" }}
+              >
+                {step.number}
+              </div>
+            </div>
+          );
+        })}
+      </Fragment>
+    );
+  }
+}

--- a/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
@@ -1,11 +1,13 @@
-import React, { Component, Fragment } from "react";
+import React, { Fragment } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setStep } from "../../../../actions/configurationProfiles";
 
-export default class StepsAside extends Component {
-  steps = [
+const StepsAside = () => {
+  const dispatch = useDispatch();
+  const steps = [
     {
       number: 1,
       description: "General data about the configuration profile",
-      active: true,
     },
     {
       number: 2,
@@ -21,27 +23,30 @@ export default class StepsAside extends Component {
     },
   ];
 
-  render() {
-    return (
-      <Fragment>
-        {this.steps.map((step) => {
-          return (
-            <div className="row justify-content-center h-100">
-              <div className="col-8">{step.description}</div>
-              <div
-                className={`col-4 rounded-circle ${
-                  step.active
-                    ? "bg-dashboard-background-highlight col-background"
-                    : "border-color-dashboard col-dashboard-highlight"
-                } p-3 text-center`}
-                style={{ maxWidth: "50px", height: "50px" }}
-              >
-                {step.number}
-              </div>
+  const currentStep = useSelector((state) => state.cpStep);
+
+  return (
+    <Fragment>
+      {steps.map((step) => {
+        return (
+          <div className="row justify-content-center h-100" key={step.number}>
+            <div className="col-8">{step.description}</div>
+            <div
+              className={`col-4 rounded-circle cursor-pointer ${
+                step.number === currentStep
+                  ? "bg-dashboard-background-highlight col-background"
+                  : "border-color-dashboard col-dashboard-highlight"
+              } p-3 text-center`}
+              style={{ maxWidth: "50px", height: "50px" }}
+              onClick={() => dispatch(setStep(step.number))}
+            >
+              {step.number}
             </div>
-          );
-        })}
-      </Fragment>
-    );
-  }
-}
+          </div>
+        );
+      })}
+    </Fragment>
+  );
+};
+
+export default StepsAside;

--- a/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/edit/StepsAside.jsx
@@ -29,7 +29,10 @@ const StepsAside = () => {
     <Fragment>
       {steps.map((step) => {
         return (
-          <div className="row justify-content-center h-100" key={step.number}>
+          <div
+            className="row justify-content-center cp-step-row"
+            key={step.number}
+          >
             <div className="col-8">{step.description}</div>
             <div
               className={`col-4 rounded-circle cursor-pointer ${

--- a/app/javascript/components/dashboard/configuration-profiles/utils.jsx
+++ b/app/javascript/components/dashboard/configuration-profiles/utils.jsx
@@ -1,0 +1,12 @@
+export const stateStyle = (state) => {
+  return {
+    color: stateColorsList[state],
+  };
+};
+
+const stateColorsList = {
+  active: "green",
+  deactivated: "grey",
+  incomplete: "red",
+  complete: "orange",
+};

--- a/app/javascript/reducers/configurationProfileStepReducer.jsx
+++ b/app/javascript/reducers/configurationProfileStepReducer.jsx
@@ -1,0 +1,10 @@
+const configurationProfileStepReducer = (state = 1, action) => {
+  switch (action.type) {
+    case "SET_STEP":
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default configurationProfileStepReducer;

--- a/app/javascript/reducers/configurationProfileStepReducer.jsx
+++ b/app/javascript/reducers/configurationProfileStepReducer.jsx
@@ -1,4 +1,4 @@
-const configurationProfileStepReducer = (state = 1, action) => {
+export const configurationProfileStepReducer = (state = 1, action) => {
   switch (action.type) {
     case "SET_STEP":
       return action.payload;
@@ -7,4 +7,11 @@ const configurationProfileStepReducer = (state = 1, action) => {
   }
 };
 
-export default configurationProfileStepReducer;
+export const currentConfigurationProfileReducer = (state = {}, action) => {
+  switch (action.type) {
+    case "SET_CURRENT_CP":
+      return action.payload;
+    default:
+      return state;
+  }
+};

--- a/app/javascript/reducers/index.jsx
+++ b/app/javascript/reducers/index.jsx
@@ -10,7 +10,10 @@ import mappingFormReducer from "./mappingFormReducer";
 import vocabulariesReducer from "./vocabulariesReducer";
 import filteredFileReducer from "./filteredFileReducer";
 import mappingFormErrorsReducer from "./mappingFormErrorsReducer";
-import configurationProfileStepReducer from "./configurationProfileStepReducer";
+import {
+  configurationProfileStepReducer,
+  currentConfigurationProfileReducer,
+} from "./configurationProfileStepReducer";
 
 /**
  * Represents a single reducer that contains all the reducers.
@@ -28,6 +31,7 @@ const allReducers = combineReducers({
   user: userReducer,
   vocabularies: vocabulariesReducer,
   cpStep: configurationProfileStepReducer,
+  currentCP: currentConfigurationProfileReducer,
 });
 
 export default allReducers;

--- a/app/javascript/reducers/index.jsx
+++ b/app/javascript/reducers/index.jsx
@@ -10,6 +10,7 @@ import mappingFormReducer from "./mappingFormReducer";
 import vocabulariesReducer from "./vocabulariesReducer";
 import filteredFileReducer from "./filteredFileReducer";
 import mappingFormErrorsReducer from "./mappingFormErrorsReducer";
+import configurationProfileStepReducer from "./configurationProfileStepReducer";
 
 /**
  * Represents a single reducer that contains all the reducers.
@@ -26,6 +27,7 @@ const allReducers = combineReducers({
   toastr: toastrReducer,
   user: userReducer,
   vocabularies: vocabulariesReducer,
+  cpStep: configurationProfileStepReducer,
 });
 
 export default allReducers;

--- a/app/javascript/services/createCP.jsx
+++ b/app/javascript/services/createCP.jsx
@@ -1,0 +1,17 @@
+import apiRequest from "./api/apiRequest";
+
+const createCP = async () => {
+  const response = await apiRequest({
+    url: "/api/v1/configuration_profiles",
+    method: "post",
+    successResponse: "configurationProfile",
+    payload: {
+      configuration_profile: {
+        name: `DESM CP - ${new Date().toISOString()}`,
+      },
+    },
+  });
+  return response;
+};
+
+export default createCP;

--- a/app/javascript/services/fetchConfigurationProfile.jsx
+++ b/app/javascript/services/fetchConfigurationProfile.jsx
@@ -1,0 +1,11 @@
+import apiRequest from "./api/apiRequest";
+
+const fetchConfigurationProfile = async (cpId) => {
+  return await apiRequest({
+    url: `/api/v1/configuration_profiles/${cpId}`,
+    method: "get",
+    successResponse: "configurationProfile",
+  });
+};
+
+export default fetchConfigurationProfile;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,112 +6,44 @@
 class User < ApplicationRecord
   attr_accessor :skip_sending_welcome_email
 
-  ###
-  # INCLUSIONS
-  ###
-
-  ###
-  # @description: Generates the password_digest to ensure it's stored in a secure way
-  ###
   has_secure_password
-  ###
-  # @description: Generates secure, unique tokens
-  ###
   include Tokenable
-  ###
-  # @description: Added because Tokenable needs the model that includes it to have a "token" named attribute
-  ###
   alias_attribute :token, :reset_password_token
-
-  ###
-  # RELATIONSHIPS
-  ###
 
   belongs_to :organization, optional: true
   has_many :assignments, dependent: :delete_all
   has_many :roles, through: :assignments
   has_many :specifications, dependent: :destroy
 
-  ###
-  # VALIDATIONS
-  ###
-
-  ###
-  # @description: It should have a fullname
-  ###
   validates :fullname, presence: true
-  ###
-  # @description: Email should be present
-  ###
   validates :email, presence: true, uniqueness: true
-  ###
-  # @description: Rules to use in the password_strength policy
-  ###
   PASSWORD_VALIDATION_RULES = {
-    ###
     # @description: Level of deductibility. 18 is the library's default, known as an acceptable level
     #   of entropy.
-    ###
     min_entropy: 15,
-    ###
-    # @description: The minimum acceptable length of the password.
-    ###
     min_word_length: MIN_PASSWORD_LENGTH,
-    ###
     # @description: Use a dictionary to improve the validation of the password.
-    ###
     use_dictionary: true
   }.freeze
-  ###
-  # @description: Uses entropy based password validation
-  ###
   validates :password, password_strength: PASSWORD_VALIDATION_RULES
 
-  ###
-  # CALLBACKS
-  ###
-
-  ###
-  # @description: Send a welcome email to the user after creation
-  ###
   after_create :send_welcome_email, unless: :skip_sending_welcome_email
 
-  ###
-  # METHODS
-  ###
-
-  ###
-  # @description: Validates whether a user has or not a given role
-  # @param [Symbol] role
-  # @return [TrueClass|FalseClass]
-  ###
   def role?(role)
     roles.any? {|r| r.name.underscore.to_sym == role }
   end
 
-  ###
-  # @description: Assigns a role to a user
-  # @param [Fixnum] role_id
-  # @return [TrueClass|FalseClass]
-  ###
   def assign_role(role_id)
     return false if Role.find(role_id) && !Assignment.where(user_id: id, role_id: role_id)
     return true if Assignment.create!(user_id: id, role_id: role_id)
   end
 
-  ###
-  # @description: Update a user's role
-  # @param [Fixnum] role_id
-  ###
   def update_role(role_id)
     assignment = Assignment.find_by_user_id(id)
     assignment.role_id = role_id
     assignment.save!
   end
 
-  ###
-  # @description: Creates a token to reset this user's password
-  ###
   def generate_password_token!
     update_columns(
       reset_password_token: generate_token,
@@ -119,32 +51,18 @@ class User < ApplicationRecord
     )
   end
 
-  ###
-  # @description: Notify the user on how to reset the password
-  ###
   def send_reset_password_instructions
     UserMailer.with(user: self).forgot_pass.deliver_later
   end
 
-  ###
-  # @description: Determines the validity of this user's password token
-  ###
   def password_token_valid?
     (reset_password_sent_at + 4.hours) > Time.now.utc
   end
 
-  ###
-  # @description: Welcomes the user with an email which let's him sign in with
-  #   a new password.
-  ###
   def send_welcome_email
     UserMailer.with(user: self).welcome.deliver_later
   end
 
-  ###
-  # @description: Update a user's password
-  # @param password [String]
-  ###
   def reset_password!(password)
     self.reset_password_token = nil
     self.password = password
@@ -152,10 +70,6 @@ class User < ApplicationRecord
     save!
   end
 
-  ###
-  # @description: Include additional information about the specification in
-  #   json responses. This overrides the ApplicationRecord as_json method.
-  ###
   def as_json(options={})
     super options.merge(methods: %i[roles organization])
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       resources :alignment_vocabulary_concepts, only: [:update]
       resources :alignment_synthetic_concepts, only: [:create]
       resources :audits, only: [:index]
-      resources :configuration_profiles, only: [:create, :index, :destroy]
+      resources :configuration_profiles, only: [:create, :index, :destroy, :show]
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
       resources :merged_files, only: [:create, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       resources :alignment_vocabulary_concepts, only: [:update]
       resources :alignment_synthetic_concepts, only: [:create]
       resources :audits, only: [:index]
-      resources :configuration_profiles, only: [:index, :destroy]
+      resources :configuration_profiles, only: [:create, :index, :destroy]
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
       resources :merged_files, only: [:create, :show]


### PR DESCRIPTION
# Description
Add steps aside component
Add Redux action and reducer to control the current CP edit page tab
Add basic 4 pages for the corresp 4 steps of editting a Configuration Profile

- Add redux actions and reducers to get the configuration profile in use updated across different tabs.
- Prepare tab components
- Navigate through tabs using the rounded numbers.
- Display DSO metadata in the first tab

# Screenshots
![cp-edit-tabs](https://user-images.githubusercontent.com/6996951/133704821-c79a7961-777c-4f0d-80b6-da4590e546ef.gif)

