### PR TITLE
Fix strongest match predicate assignment during CP activation

### DIFF
--- a/app/interactors/create_cp_structure.rb
+++ b/app/interactors/create_cp_structure.rb
@@ -60,7 +60,11 @@ class CreateCpStructure
   end
 
   def generate_mapping_predicates
-    result = CreateMappingPredicates.call({json_body: @cp.json_mapping_predicates})
+    result = CreateMappingPredicates.call(
+      json_body: @cp.json_mapping_predicates,
+      strongest_match: @cp.predicate_strongest_match
+    )
+
     raise MappingPredicatesCreationError.new("MappingPredicatesCreationError: #{result.error}") unless result.error.nil?
 
     @cp.update(mapping_predicates: result.predicate_set)

--- a/app/javascript/components/align-and-fine-tune/SpineTermRow.jsx
+++ b/app/javascript/components/align-and-fine-tune/SpineTermRow.jsx
@@ -46,9 +46,15 @@ const SpineTermRow = (props) => {
   const [editMode, setEditMode] = useState("comment");
 
   /**
-   * The predicate option selected
+   * The predicate option selected (the strongest match predicate by default)
    */
-  const [predicate, setPredicate] = useState(findPredicate());
+  const [predicate, setPredicate] = useState(() =>
+    (
+      alignment.predicateId
+        ? predicates.find((predicate) => predicate.id === alignment.predicateId)
+        : predicates.find((predicate) => predicate.strongest_match)
+    ).pref_label
+  );
 
   /**
    * Whether we are editing the alignment or not. Set to true when
@@ -70,14 +76,10 @@ const SpineTermRow = (props) => {
   );
 
   /**
-   * If the mapping term (alignment) has a predicate selected, lets find it
+   * If the mapping term (alignment) has a predicate selected, lets find it.
+   * Otherwise use the strongest match predicate
    */
-  function findPredicate() {
-    return alignment.predicateId
-      ? predicates.find((predicate) => predicate.id === alignment.predicateId)
-          .pref_label
-      : null;
-  }
+  // const findPredicate = ;
 
   /**
    * Return the options for an alignment that is a alignment that has

--- a/app/models/predicate.rb
+++ b/app/models/predicate.rb
@@ -109,7 +109,11 @@ class Predicate < ApplicationRecord
   #   json responses. This overrides the ApplicationRecord as_json method.
   ###
   def as_json(options={})
-    super options.merge(methods: %i[uri])
+    super(
+      options.merge(methods: %i[uri])
+    ).merge(
+      strongest_match: predicate_set.strongest_match_id == id
+    )
   end
 
   private

--- a/app/models/predicate_set.rb
+++ b/app/models/predicate_set.rb
@@ -11,8 +11,10 @@ class PredicateSet < ApplicationRecord
   include Slugable
   validates :source_uri, presence: true
   validates :title, presence: true
+
+  belongs_to :strongest_match, class_name: "Predicate", optional: true
   has_many :predicates
-  belongs_to :strongest_match, foreign_key: "strongest_match_id", class_name: "Predicate", optional: true
+
   alias_attribute :name, :title
 
   def to_json_ld

--- a/app/services/processors/predicates.rb
+++ b/app/services/processors/predicates.rb
@@ -86,11 +86,9 @@ module Processors
     end
 
     def assign_strongest_match
-      sm = @predicate_set.predicates.find_by_pref_label(@strongest_match) if @strongest_match.present?
-      sm = @predicate_set.predicates.first if sm.nil?
-
-      @predicate_set.strongest_match = sm
-      @predicate_set.save!
+      predicate = @predicate_set.predicates.find_by(source_uri: @strongest_match)
+      predicate ||= @predicate_set.predicates.first
+      @predicate_set.update!(strongest_match: predicate)
     end
   end
 end


### PR DESCRIPTION
Also, pre-populate strongest match predicate in mapping form

Ref. #205