### PR TITLE
Use title as name if label is empty when creating terms

### DIFF
--- a/app/services/processors/specifications.rb
+++ b/app/services/processors/specifications.rb
@@ -274,7 +274,7 @@ module Processors
     ###
     def create_one_term(instance, node)
       parser = Parsers::JsonLd::Node.new(node)
-      name = parser.read!("label")
+      name = parser.read!("label").presence || parser.read!("title")
 
       Term
         .create_with(


### PR DESCRIPTION
Ref. #247