### PR TITLE
(#472) prevented removal term with mappings

### DIFF
--- a/app/javascript/components/edit-specification/EditSpecification.jsx
+++ b/app/javascript/components/edit-specification/EditSpecification.jsx
@@ -1,7 +1,5 @@
-import { useContext, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
-import fetchSpine from '../../services/fetchSpine';
-import fetchSpineTerms from '../../services/fetchSpineTerms';
+import { useContext, useEffect } from 'react';
+import { useLocalStore } from 'easy-peasy';
 import EditTerm from '../mapping-to-domains/EditTerm';
 import TermCard from '../mapping-to-domains/TermCard';
 import AlertNotice from '../shared/AlertNotice';
@@ -12,52 +10,15 @@ import Pluralize from 'pluralize';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { AppContext } from '../../contexts/AppContext';
+import { specificationStore } from './stores/specificationStore';
 
 const EditSpecification = (props) => {
   const { organization } = useContext(AppContext);
+  const [state, actions] = useLocalStore(() => specificationStore());
+  const { editingTerm, domain, terms, termToEdit, termsInputValue } = state;
 
-  /**
-   * Error message to present on the UI
-   */
-  const [errors, setErrors] = useState([]);
-
-  /**
-   * Whether the page is loading results or not
-   */
-  const [loading, setLoading] = useState(true);
-
-  /**
-   * The logged in user
-   */
-  const user = useSelector((state) => state.user);
-
-  /**
-   * Declare and have an initial state for the domain
-   */
-  const [domain, setDomain] = useState({});
-
-  /**
-   * The terms of the spine
-   */
-  const [terms, setTerms] = useState([]);
-
-  /**
-   * The value of the input that the user is typing in the search box
-   * to filter the list of terms
-   */
-  const [termsInputValue, setTermsInputValue] = useState('');
-
-  /**
-   * Whether we are editing a term or not. Useful to show/hide the
-   * modal window to edit a term
-   */
-  const [editingTerm, setEditingTerm] = useState(false);
-
-  /**
-   * The term to be edited. Active when the user clicks the pencil
-   * icon on a term
-   */
-  const [termToEdit, setTermToEdit] = useState({ property: {} });
+  // Manage to change values from inputs in the state
+  const filterTermsOnChange = (event) => actions.setTermsInputValue(event.target.value);
 
   /**
    * Configure the options to see at the center of the top navigation bar
@@ -67,127 +28,37 @@ const EditSpecification = (props) => {
   };
 
   /**
-   * Manage to change values from inputs in the state
-   *
-   * @param {Event} event
-   */
-  const filterTermsOnChange = (event) => {
-    setTermsInputValue(event.target.value);
-  };
-
-  /**
-   * The terms that includes the string typed by the user in the search box.
-   */
-  const filteredTerms = () =>
-    terms
-      .filter((term) => {
-        return term.name.toLowerCase().includes(termsInputValue.toLowerCase());
-      })
-      .sort((a, b) => (a.name > b.name ? 1 : -1));
-
-  /**
-   * Handles to view the modal window that allows to edit a term
-   *
-   * @param {Object} term
-   */
-  const onEditTermClick = (term) => {
-    setEditingTerm(true);
-    setTermToEdit(term);
-  };
-
-  /**
-   * Actions on term removed. The term was removed using another component,
-   * so in this one, it's still visible, we need to change that to also
-   * don't show it.
-   *
-   * @param {Object} removedTerm
-   */
-  const termRemoved = (removedTerm) => {
-    const tempTerms = terms.filter((term) => term.id !== removedTerm.id);
-    setTerms(tempTerms);
-  };
-
-  /**
-   * Handle showing the errors on screen, if any
-   *
-   * @param {HttpResponse} response
-   */
-  function anyError(response) {
-    if (response.error) {
-      let tempErrors = errors;
-      tempErrors.push(response.error);
-      setErrors([]);
-      setErrors(tempErrors);
-    }
-    /// It will return a truthy value (depending no the existence
-    /// of the errors on the response object)
-    return !_.isUndefined(response.error);
-  }
-
-  /**
-   * Get the specification
-   */
-  const handleFetchSpine = async (spineId) => {
-    let response = await fetchSpine(spineId);
-    if (!anyError(response)) {
-      // Set the domain on state
-      setDomain(response.spine.domain);
-    }
-  };
-
-  /**
-   * Get the specification terms
-   */
-  const handleFetchSpineTerms = async (spineId) => {
-    let response = await fetchSpineTerms(spineId);
-    if (!anyError(response)) {
-      // Set the spine terms on state
-      setTerms(response.terms);
-    }
-  };
-
-  /**
-   * Get the data from the service
-   */
-  const fetchDataFromAPI = async () => {
-    // Get the specification
-    await handleFetchSpine(props.match.params.id);
-    // Get the terms
-    await handleFetchSpineTerms(props.match.params.id);
-  };
-
-  /**
    * Use effect with an emtpy array as second parameter, will trigger the 'fetchDataFromAPI'
    * action at the 'mounted' event of this functional component (It's not actually mounted,
    * but it mimics the same action).
    */
   useEffect(() => {
-    if (loading) {
-      fetchDataFromAPI().then(() => {
-        if (_.isEmpty(errors)) {
-          setLoading(false);
-        }
-      });
-    }
+    actions.fetchDataFromAPI({ spineId: props.match.params.id }).then(() => {
+      if (!state.hasErrors) {
+        actions.setLoading(false);
+      }
+    });
   }, []);
 
   return (
     <>
       <EditTerm
         modalIsOpen={editingTerm}
-        onRequestClose={() => {
-          setEditingTerm(false);
-        }}
-        onRemoveTerm={termRemoved}
+        onRequestClose={() => actions.setEditingTerm(false)}
+        onRemoveTerm={actions.onRemoveTerm}
         termId={termToEdit.id}
       />
       <div className="container-fluid">
         <TopNav centerContent={navCenterOptions} />
 
-        {errors.length ? <AlertNotice message={errors} /> : ''}
+        {state.hasErrors ? (
+          <AlertNotice message={state.errors} onClose={actions.clearErrors} />
+        ) : (
+          ''
+        )}
 
         <div className="row">
-          {loading ? (
+          {state.loading ? (
             <Loader />
           ) : (
             <div className="col p-lg-5 pt-5 bg-col-secondary">
@@ -231,7 +102,7 @@ const EditSpecification = (props) => {
                   message="You can edit each term of your specification until you are confident with names, vocabularies, uri's and more."
                 />
                 <div className="has-scrollbar scrollbar pr-5">
-                  {filteredTerms().map((term) => {
+                  {state.filteredTerms.map((term) => {
                     return (
                       <TermCard
                         key={term.id}
@@ -239,7 +110,7 @@ const EditSpecification = (props) => {
                         onClick={() => {}}
                         isMapped={() => false}
                         editEnabled={true}
-                        onEditClick={onEditTermClick}
+                        onEditClick={actions.onEditTermClick}
                         disableClick={true}
                       />
                     );

--- a/app/javascript/components/edit-specification/stores/specificationStore.js
+++ b/app/javascript/components/edit-specification/stores/specificationStore.js
@@ -1,0 +1,72 @@
+import { action, computed, thunk } from 'easy-peasy';
+import { remove } from 'lodash';
+import { baseModel } from '../../stores/baseModel';
+import { easyStateSetters } from '../../stores/easyState';
+import fetchSpine from '../../../services/fetchSpine';
+import fetchSpineTerms from '../../../services/fetchSpineTerms';
+import { filterTerms } from '../../align-and-fine-tune/stores/mappingStore';
+
+export const defaultState = {
+  // status
+  // Whether we are editing a term or not. Useful to show/hide the modal window to edit a term
+  editingTerm: false,
+
+  // data
+  // Domain
+  domain: {},
+  // The specification terms list
+  terms: [],
+  // The term to be edited. Active when the user clicks the pencil icon on a term
+  termToEdit: { property: {} },
+  // The value of the input that the user is typing in the search box to filter the list of terms
+  termsInputValue: '',
+};
+
+export const specificationStore = (initialData = {}) => ({
+  ...baseModel(initialData),
+  ...easyStateSetters(defaultState, initialData),
+
+  // computed
+  filteredTerms: computed((state) => filterTerms(state.terms, state.termsInputValue)),
+
+  // actions
+  // Handles to view the modal window that allows to edit a term
+  onEditTermClick: action((state, term) => {
+    state.editingTerm = true;
+    state.termToEdit = term;
+  }),
+  onRemoveTerm: action((state, term) => {
+    remove(state.terms, (t) => t.id === term.id);
+  }),
+
+  // thunks
+  // Get the specification
+  handleFetchSpine: thunk(async (actions, { spineId }, h) => {
+    const state = h.getState();
+    const response = await fetchSpine(spineId);
+    if (state.withoutErrors(response)) {
+      actions.setDomain(response.spine.domain);
+    } else {
+      actions.addError(response.error);
+    }
+    return response;
+  }),
+  // Get the specification terms
+  handleFetchSpineTerms: thunk(async (actions, { spineId }, h) => {
+    const state = h.getState();
+    const response = await fetchSpineTerms(spineId);
+    if (state.withoutErrors(response)) {
+      actions.setTerms(response.terms);
+    } else {
+      actions.addError(response.error);
+    }
+    return response;
+  }),
+  // Fetch initial data
+  fetchDataFromAPI: thunk(async (actions, { spineId }) => {
+    // Get the specification
+    await actions.handleFetchSpine({ spineId });
+    // Get the terms
+    await actions.handleFetchSpineTerms({ spineId });
+  }),
+});

--- a/app/javascript/components/mapping-to-domains/EditTerm.jsx
+++ b/app/javascript/components/mapping-to-domains/EditTerm.jsx
@@ -138,7 +138,7 @@ export default class EditTerm extends Component {
         this.setState({ error: response.error });
         return;
       }
-      this.props.onRequestClose();
+      this.closeRequested();
       showSuccess('Changes Saved to  ' + this.state.term.name);
     });
   };
@@ -150,9 +150,10 @@ export default class EditTerm extends Component {
     deleteTerm(this.state.term.id).then((response) => {
       if (response.error) {
         this.setState({ error: response.error });
+        return;
       }
       this.props.onRemoveTerm(this.state.term);
-      this.props.onRequestClose();
+      this.closeRequested();
       showInfo('Term removed: ' + this.state.term.name);
     });
   };
@@ -202,7 +203,7 @@ export default class EditTerm extends Component {
    */
   fetchTermFromApi = () => {
     if (this.props.termId) {
-      fetchTerm(this.props.termId).then((response) => {
+      fetchTerm(this.props.termId, { withMapping: true }).then((response) => {
         if (response.error) {
           this.setState({ error: response.error });
           return;
@@ -220,6 +221,7 @@ export default class EditTerm extends Component {
    */
   closeRequested = () => {
     this.setState({ loading: true });
+    this.setState({ error: null });
     this.props.onRequestClose();
   };
 
@@ -250,7 +252,7 @@ export default class EditTerm extends Component {
     /**
      * Elements from props
      */
-    const { modalIsOpen, onRequestClose } = this.props;
+    const { modalIsOpen } = this.props;
 
     return (
       <Modal
@@ -271,7 +273,7 @@ export default class EditTerm extends Component {
                 </h4>
               </div>
               <div className="col-6">
-                <a className="float-right cursor-pointer" onClick={onRequestClose}>
+                <a className="float-right cursor-pointer" onClick={this.closeRequested}>
                   <FontAwesomeIcon icon={faTimes} aria-hidden="true" />
                 </a>
               </div>

--- a/app/javascript/services/api/apiRequest.jsx
+++ b/app/javascript/services/api/apiRequest.jsx
@@ -1,5 +1,6 @@
-import { camelizeKeys } from 'humps';
+import { camelizeKeys, decamelizeKeys } from 'humps';
 import apiService, { processMessage } from './apiService';
+import { chain, pickBy, identity, isNil } from 'lodash';
 /**
  * Manages the api requests
  *
@@ -26,10 +27,11 @@ import apiService, { processMessage } from './apiService';
  */
 const apiRequest = async (props) => {
   validateParams(props);
+  const queryParams = queryString(props.queryParams || {});
 
   // Do the request
   const response = await apiService({
-    url: props.url,
+    url: `${props.url}${queryParams ? `?${queryParams}` : ''}`,
     method: props.method,
     data: props.payload,
     options: props.options,
@@ -69,6 +71,17 @@ const validateParams = (props) => {
   if (!_.has(props, 'method')) {
     throw 'Method not provided';
   }
+};
+
+const queryString = (params) => {
+  const esc = encodeURIComponent;
+  const queryParams = pickBy(params, identity);
+
+  return chain(decamelizeKeys(queryParams))
+    .map((v, k) => (isNil(v) ? null : `${esc(k)}=${esc(v)}`))
+    .filter()
+    .value()
+    .join('&');
 };
 
 export default apiRequest;

--- a/app/javascript/services/fetchSpineTerms.jsx
+++ b/app/javascript/services/fetchSpineTerms.jsx
@@ -1,12 +1,13 @@
 import { camelizeKeys } from 'humps';
 import apiRequest from './api/apiRequest';
 
-const fetchSpineTerms = async (specId) => {
+const fetchSpineTerms = async (specId, queryParams = {}) => {
   const response = await apiRequest({
     url: '/api/v1/spines/' + specId + '/terms',
     defaultResponse: [],
     successResponse: 'terms',
     method: 'get',
+    queryParams,
   });
   return camelizeKeys(response);
 };

--- a/app/javascript/services/fetchTerm.jsx
+++ b/app/javascript/services/fetchTerm.jsx
@@ -1,12 +1,13 @@
 import { camelizeKeys } from 'humps';
 import apiRequest from './api/apiRequest';
 
-const fetchTerm = async (termId) => {
+const fetchTerm = async (termId, queryParams = {}) => {
   let response = await apiRequest({
     url: '/api/v1/terms/' + termId,
     method: 'get',
     defaultResponse: {},
     successResponse: 'term',
+    queryParams,
   });
 
   return camelizeKeys(response);

--- a/app/models/alignment.rb
+++ b/app/models/alignment.rb
@@ -25,6 +25,7 @@
 #
 #  fk_rails_...  (mapping_id => mappings.id) ON DELETE => cascade
 #  fk_rails_...  (predicate_id => predicates.id)
+#  fk_rails_...  (spine_term_id => terms.id) ON DELETE => restrict
 #  fk_rails_...  (vocabulary_id => vocabularies.id)
 #
 

--- a/db/migrate/20240311132038_add_foreign_key_to_alignments.rb
+++ b/db/migrate/20240311132038_add_foreign_key_to_alignments.rb
@@ -1,0 +1,6 @@
+class AddForeignKeyToAlignments < ActiveRecord::Migration[6.1]
+def change
+    # Add a foreign key constraint to the alignments table with ON DELETE RESTRICT
+    add_foreign_key :alignments, :terms, column: :spine_term_id, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_10_200715) do
+ActiveRecord::Schema.define(version: 2024_03_11_132038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -357,6 +357,7 @@ ActiveRecord::Schema.define(version: 2024_03_10_200715) do
   add_foreign_key "alignment_vocabulary_concepts", "predicates"
   add_foreign_key "alignments", "mappings", on_delete: :cascade
   add_foreign_key "alignments", "predicates"
+  add_foreign_key "alignments", "terms", column: "spine_term_id", on_delete: :restrict
   add_foreign_key "alignments", "vocabularies"
   add_foreign_key "assignments", "roles"
   add_foreign_key "assignments", "users"

--- a/spec/factories/alignments.rb
+++ b/spec/factories/alignments.rb
@@ -25,6 +25,7 @@
 #
 #  fk_rails_...  (mapping_id => mappings.id) ON DELETE => cascade
 #  fk_rails_...  (predicate_id => predicates.id)
+#  fk_rails_...  (spine_term_id => terms.id) ON DELETE => restrict
 #  fk_rails_...  (vocabulary_id => vocabularies.id)
 #
 require "faker"

--- a/spec/models/alignment_spec.rb
+++ b/spec/models/alignment_spec.rb
@@ -25,6 +25,7 @@
 #
 #  fk_rails_...  (mapping_id => mappings.id) ON DELETE => cascade
 #  fk_rails_...  (predicate_id => predicates.id)
+#  fk_rails_...  (spine_term_id => terms.id) ON DELETE => restrict
 #  fk_rails_...  (vocabulary_id => vocabularies.id)
 #
 require "rails_helper"

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -30,4 +30,19 @@ describe Term do
     is_expected.to validate_presence_of(:raw)
     is_expected.to have_and_belong_to_many(:specifications)
   end
+
+  describe "#destroy" do
+    it "raises an error if the term has alignments" do
+      term = create(:term)
+      create(:alignment, spine_term: term)
+
+      expect { term.destroy }.to raise_error(RuntimeError)
+    end
+
+    it "destroys the term if it has no alignments" do
+      term = create(:term)
+
+      expect { term.destroy }.to change { Term.count }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
#472

Note: if there will be foreign key related issues during deployments more likely it means that we have alignments with `spine_term_id` pointed to non existing term. To remove those there is one off task `oneoff:remove_inconsistent_alignments`