### PR TITLE
(#345) added agent list view

### DIFF
--- a/.cloud66/deploy_hooks.yml
+++ b/.cloud66/deploy_hooks.yml
@@ -1,0 +1,13 @@
+default: &default
+  after_bundle:
+    - command: cd $STACK_PATH && bundle exec i18n export --require ./config/i18n_export.rb
+      target: rails
+      execute: true
+      run_on: all_servers
+      apply_during: all
+
+production:
+  <<: *default
+
+staging:
+  <<: *default

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ yarn-debug.log*
 # simplecov reports
 coverage
 
+# Ignore translation files
+app/javascript/translations/locales.json
+

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 # For http requests
 gem "httparty"
 
+gem "i18n-js", "~> 4.2"
 gem "interactor-rails", "~> 2.0"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -56,6 +57,7 @@ gem "open_uri_redirections", "~> 0.2"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"
+gem "pg_search", "~> 2.3"
 
 # Use Puma as the app server
 gem "puma", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
+    glob (0.4.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
     haml (6.3.0)
@@ -166,6 +167,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-js (4.2.3)
+      glob (>= 0.4.0)
+      i18n
     iniparse (1.5.0)
     interactor (3.1.2)
     interactor-rails (2.2.1)
@@ -288,6 +292,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -600,6 +607,7 @@ DEPENDENCIES
   faker
   htmlbeautifier
   httparty
+  i18n-js (~> 4.2)
   interactor-rails (~> 2.0)
   json-schema
   json_schema_tools (~> 0.6)
@@ -612,6 +620,7 @@ DEPENDENCIES
   open_uri_redirections (~> 0.2)
   overcommit
   pg (>= 0.18, < 2.0)
+  pg_search (~> 2.3)
   puma (~> 4.1)
   pundit
   rack-cors

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -5,3 +5,14 @@
 p.card-text {
   margin-bottom: $card-spacer-y;
 }
+
+.card {
+  @include m(link) {
+    cursor: pointer;
+
+    &:hover {
+      background-color: $dashboard-background-color-highlight2 !important;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/utils/_utilities.scss
+++ b/app/assets/stylesheets/utils/_utilities.scss
@@ -80,3 +80,7 @@
 
   color: inherit !important;
 }
+
+.white-space-pre-line {
+  white-space: pre-line !important;
+}

--- a/app/controllers/api/v1/admins_controller.rb
+++ b/app/controllers/api/v1/admins_controller.rb
@@ -3,7 +3,7 @@
 module API
   module V1
     class AdminsController < BaseController
-      before_action :authorize!
+      include AuthAdmin
       before_action :load_admin, only: %i(update destroy)
 
       def index
@@ -35,11 +35,7 @@ module API
       end
 
       def admin_role
-        Role.find_by!(name: "super admin")
-      end
-
-      def authorize!
-        raise Pundit::NotAuthorizedError unless current_user&.super_admin?
+        Role.find_by!(name: Desm::ADMIN_ROLE_NAME.downcase)
       end
 
       def load_admin

--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class AgentsController < BaseController
+      include AuthAdmin
+
+      def index
+        authorize User, policy_class: AgentPolicy
+        @agents = AgentsQuery.call(policy_scope(User, policy_scope_class: AgentPolicy::Scope), params: agents_params)
+
+        render json: @agents.includes(:configuration_profile_users), each_serializer: AgentSerializer,
+               with_configuration_profiles: true
+      end
+
+      def filters
+        render json: {
+          organizations: serialize_filters_for(policy_scope(Organization)),
+          configuration_profiles: serialize_filters_for(policy_scope(ConfigurationProfile).activated),
+          states: ConfigurationProfile.states_for_select[-2..]
+        }
+      end
+
+      private
+
+      def agents_params
+        params.permit(:search, configuration_profile_ids: [], configuration_profile_states: [], organization_ids: [])
+      end
+
+      def serialize_filters_for(data)
+        ActiveModel::Serializer::CollectionSerializer.new(data.order(:name), serializer: PreviewSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -17,7 +17,7 @@ module API
         render json: {
           organizations: serialize_filters_for(policy_scope(Organization)),
           configuration_profiles: serialize_filters_for(policy_scope(ConfigurationProfile).activated),
-          states: ConfigurationProfile.states_for_select[-2..]
+          states: ConfigurationProfile.activated_states_for_select
         }
       end
 

--- a/app/controllers/api/v1/dashboard_controller.rb
+++ b/app/controllers/api/v1/dashboard_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class DashboardController < BaseController
+      include AuthAdmin
+
+      def index
+        stats = DashboardStatsQuery.call(current_user)
+        states = [{ id: "all", name: "All" }].concat(ConfigurationProfile.states_for_select)
+        render json: { stats:, states: }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/auth_admin.rb
+++ b/app/controllers/concerns/auth_admin.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AuthAdmin
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize!
+  end
+
+  private
+
+  def authorize!
+    raise Pundit::NotAuthorizedError unless current_user&.super_admin?
+  end
+end

--- a/app/javascript/components/Routes.jsx
+++ b/app/javascript/components/Routes.jsx
@@ -1,3 +1,4 @@
+import AgentsIndex from './dashboard/agents/AgentsIndex';
 import UsersIndex from './dashboard/users/UsersIndex';
 import EditUser from './dashboard/users/EditUser';
 import Registration from './auth/Registration';
@@ -120,6 +121,13 @@ const Routes = (props) => {
           path="/dashboard/configuration-profiles/:id"
           allowedRoles={onlySuperAdmin}
           component={EditConfigurationProfile}
+        />
+
+        <ProtectedRoute
+          exact
+          path="/dashboard/agents"
+          component={AgentsIndex}
+          allowedRoles={onlySuperAdmin}
         />
 
         <ProtectedRoute

--- a/app/javascript/components/dashboard/MainDashboard.jsx
+++ b/app/javascript/components/dashboard/MainDashboard.jsx
@@ -1,28 +1,41 @@
-import { Component } from 'react';
+import { useEffect } from 'react';
 import DashboardContainer from './DashboardContainer';
 import AlertNotice from '../shared/AlertNotice';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
-import fetchConfigurationProfiles from '../../services/fetchConfigurationProfiles';
-import fetchMappings from '../../services/fetchMappings';
+import { useLocalStore } from 'easy-peasy';
+import { dashboardStore } from './stores/dashboardStore';
+import { pageRoutes } from '../../services/pageRoutes';
+import classNames from 'classnames';
 
-export default class MainDashboard extends Component {
-  state = {
-    configurationProfiles: [],
-    errors: '',
-    filterOptions: [
-      { id: 1, name: 'All' },
-      { id: 2, name: 'Incomplete' },
-      { id: 3, name: 'Complete' },
-      { id: 4, name: 'Active' },
-      { id: 5, name: 'Deactivated' },
-    ],
-    mappings: [],
-    selectedOptionId: 1,
-  };
+const InfoBox = (props) => {
+  const { count, text, link = null } = props;
+  const cssCard = classNames('card bg-dashboard-background', { 'card--link': !!link });
+  const cardBody = () => (
+    <div className="card-body rounded col-background text-center">
+      <h2>{count}</h2>
+      <p>{text}</p>
+    </div>
+  );
 
-  dashboardPath = () => {
+  return link ? (
+    <Link className={cssCard} style={{ height: '8rem' }} to={link}>
+      {cardBody()}
+    </Link>
+  ) : (
+    <div className={cssCard} style={{ height: '8rem' }}>
+      {cardBody()}
+    </div>
+  );
+};
+
+const MainDashboard = (_props = {}) => {
+  const [state, actions] = useLocalStore(() => dashboardStore());
+
+  useEffect(() => actions.fetchData(), []);
+
+  const dashboardPath = () => {
     return (
       <div className="float-right">
         <FontAwesomeIcon icon={faHome} className="mr-2" />{' '}
@@ -36,165 +49,66 @@ export default class MainDashboard extends Component {
     );
   };
 
-  fetchConfigurationProfilesAPI() {
-    fetchConfigurationProfiles().then((response) => {
-      if (response.error) {
-        this.setState({
-          errors: response.error,
-        });
-        return;
-      }
-      this.setState({
-        configurationProfiles: response.configurationProfiles,
-      });
-    });
-  }
-
-  fetchMappingsAPI() {
-    fetchMappings().then((response) => {
-      if (response.error) {
-        this.setState({
-          errors: response.error,
-        });
-        return;
-      }
-      this.setState({
-        mappings: response.mappings,
-      });
-    });
-  }
-
-  fetchData() {
-    this.fetchConfigurationProfilesAPI();
-    this.fetchMappingsAPI();
-  }
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  filteredCps = () => {
-    switch (this.state.selectedOptionId) {
-      case '1':
-        return this.state.configurationProfiles;
-      case '2':
-        return this.state.configurationProfiles.filter((cp) => cp.state === 'incomplete');
-      case '3':
-        return this.state.configurationProfiles.filter((cp) => cp.state === 'complete');
-      case '4':
-        return this.state.configurationProfiles.filter((cp) => cp.state === 'active');
-      case '5':
-        return this.state.configurationProfiles.filter((cp) => cp.state === 'deactivated');
-      default:
-        return this.state.configurationProfiles;
-    }
-  };
-
-  dsosCount = () =>
-    this.filteredCps()
-      .map((cp) => cp.structure.standardsOrganizations?.length || 0)
-      .reduce((a, b) => a + b, 0);
-
-  cpsCount = () => this.filteredCps().length;
-
-  agentsCount = () =>
-    this.filteredCps()
-      .map((cp) =>
-        (cp.structure.standardsOrganizations || [])
-          .map((dso) => dso.dsoAgents?.length || 0)
-          .reduce((a, b) => a + b, 0)
-      )
-      .reduce((a, b) => a + b, 0);
-
-  activeMappingsCount = () =>
-    this.state.mappings.filter((mapping) => mapping['in_progress?']).length;
-
-  schemesCount = () =>
-    this.filteredCps()
-      .map((cp) =>
-        (cp.structure.standardsOrganizations || [])
-          .map((dso) => dso.associatedSchemas?.length || 0)
-          .reduce((a, b) => a + b, 0)
-      )
-      .reduce((a, b) => a + b, 0);
-
-  render() {
-    const { errors, filterOptions } = this.state;
-
-    return (
-      <DashboardContainer>
-        {this.dashboardPath()}
-        <div className="col col-md-10 mt-5">
-          <div className="row h-50 ml-5">
-            <div className="col-3 py-3">
-              <div
-                className="form-group"
-                onChange={(e) => {
-                  this.setState({ selectedOptionId: e.target.value });
-                }}
-              >
-                {filterOptions.map(function (opt) {
-                  return (
-                    <div key={opt.id}>
-                      <input
-                        type="radio"
-                        value={opt.id}
-                        name="filterOption"
-                        id={`filterOption-${opt.id}`}
-                        required={true}
-                        defaultChecked={opt.id === 1}
-                      />
-                      <label className="ml-2 cursor-pointer" htmlFor={`filterOption-${opt.id}`}>
-                        {opt.name}
-                      </label>
-                    </div>
-                  );
-                })}
-              </div>
+  return (
+    <DashboardContainer>
+      {dashboardPath()}
+      <div className="col col-md-10 mt-5">
+        <div className="row h-50 ml-5">
+          <div className="col-3 py-3">
+            <div
+              className="form-group"
+              onChange={(e) => actions.setSelectedOptionId(e.target.value)}
+            >
+              {state.filterOptions.map(function (opt) {
+                return (
+                  <div key={opt.id}>
+                    <input
+                      type="radio"
+                      value={opt.id}
+                      name="filterOption"
+                      id={`filterOption-${opt.id}`}
+                      required={true}
+                      defaultChecked={opt.id === 'all'}
+                    />
+                    <label className="ml-2 cursor-pointer" htmlFor={`filterOption-${opt.id}`}>
+                      {opt.name}
+                    </label>
+                  </div>
+                );
+              })}
             </div>
-            <div className="col-9">
-              {errors && (
-                <AlertNotice message={errors} onClose={() => this.setState({ errors: '' })} />
-              )}
+          </div>
+          <div className="col-9">
+            {state.hasErrors ? (
+              <AlertNotice message={state.errors} onClose={actions.clearErrors} />
+            ) : null}
 
-              <div className="row">
-                <div className="col-xl-3 col-sm-6 py-2">
-                  <InfoBox count={this.cpsCount()} text={'Configuration Profiles'} />
-                </div>
+            <div className="row">
+              <div className="col-xl-3 col-sm-6 py-2">
+                <InfoBox count={state.cpsCount} text={'Configuration Profiles'} />
+              </div>
 
-                <div className="col-xl-3 col-sm-6 py-2">
-                  <InfoBox count={this.dsosCount()} text={'Data Standards Organizations'} />
-                </div>
+              <div className="col-xl-3 col-sm-6 py-2">
+                <InfoBox count={state.dsosCount} text={'Data Standards Organizations'} />
+              </div>
 
-                <div className="col-xl-3 col-sm-6 py-2">
-                  <InfoBox count={this.agentsCount()} text={'Agents'} />
-                </div>
+              <div className="col-xl-3 col-sm-6 py-2">
+                <InfoBox count={state.agentsCount} text={'Agents'} link={pageRoutes.agents()} />
+              </div>
 
-                <div className="col-xl-3 col-sm-6 py-2">
-                  <InfoBox count={this.activeMappingsCount()} text={'Active Mappings'} />
-                </div>
+              <div className="col-xl-3 col-sm-6 py-2">
+                <InfoBox count={state.activeMappingsCount} text={'Active Mappings'} />
+              </div>
 
-                <div className="col-xl-3 col-sm-6 py-2">
-                  <InfoBox count={this.schemesCount()} text={'Schemes'} />
-                </div>
+              <div className="col-xl-3 col-sm-6 py-2">
+                <InfoBox count={state.schemesCount} text={'Schemes'} />
               </div>
             </div>
           </div>
         </div>
-      </DashboardContainer>
-    );
-  }
-}
-
-const InfoBox = (props) => {
-  const { count, text } = props;
-
-  return (
-    <div className="card" style={{ height: '8rem' }}>
-      <div className="card-body rounded bg-dashboard-background col-background text-center">
-        <h2>{count}</h2>
-        <p>{text}</p>
       </div>
-    </div>
+    </DashboardContainer>
   );
 };
+
+export default MainDashboard;

--- a/app/javascript/components/dashboard/SideBar.jsx
+++ b/app/javascript/components/dashboard/SideBar.jsx
@@ -1,16 +1,14 @@
 import {} from 'react';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCog, faCogs, faUser } from '@fortawesome/free-solid-svg-icons';
+import { faCog, faCogs, faUser, faUsers } from '@fortawesome/free-solid-svg-icons';
+import { pageRoutes } from 'services/pageRoutes';
+import { i18n } from 'utils/i18n';
 
 const SideBar = () => {
-  const navLinks = {
-    dashboard: '/dashboard',
-    users: '/dashboard/users',
-    organizations: '/dashboard/organizations',
-    configuration_profiles: '/dashboard/configuration-profiles',
-    admins: '/dashboard/admins',
-  };
+  const cssNavClass = (path) =>
+    window.location.pathname === path ? 'selected-dashboard-option ' : '';
+  const cssNavBase = 'nav-link cursor-pointer col-background pl-3';
 
   return (
     <>
@@ -20,12 +18,8 @@ const SideBar = () => {
             <ul className="flex-md-column flex-row navbar-nav w-100 justify-content-between">
               <li className="nav-item">
                 <Link
-                  to={navLinks.dashboard}
-                  className={`${
-                    window.location.pathname === navLinks.dashboard
-                      ? 'selected-dashboard-option '
-                      : ''
-                  }nav-link cursor-pointer col-background pl-3`}
+                  to={pageRoutes.dashboard()}
+                  className={`${cssNavClass(pageRoutes.dashboard())} ${cssNavBase}`}
                 >
                   <FontAwesomeIcon fixedWidth icon={faCog} aria-hidden="true" />
                   <span className="pl-2">Dashboard</span>
@@ -34,10 +28,8 @@ const SideBar = () => {
 
               <li className="nav-item">
                 <Link
-                  to={navLinks.admins}
-                  className={`${
-                    window.location.pathname === navLinks.admins ? 'selected-dashboard-option ' : ''
-                  }nav-link cursor-pointer col-background pl-3`}
+                  to={pageRoutes.admins()}
+                  className={`${cssNavClass(pageRoutes.admins())} ${cssNavBase}`}
                 >
                   <FontAwesomeIcon fixedWidth icon={faUser} aria-hidden="true" />
                   <span className="pl-2">Admin Users</span>
@@ -46,12 +38,18 @@ const SideBar = () => {
 
               <li className="nav-item">
                 <Link
-                  to={navLinks.configuration_profiles}
-                  className={`${
-                    window.location.pathname === navLinks.configuration_profiles
-                      ? 'selected-dashboard-option '
-                      : ''
-                  }nav-link cursor-pointer col-background pl-3`}
+                  to={pageRoutes.agents()}
+                  className={`${cssNavClass(pageRoutes.agents())} ${cssNavBase}`}
+                >
+                  <FontAwesomeIcon fixedWidth icon={faUsers} aria-hidden="true" />
+                  <span className="pl-2">{i18n.t('ui.dashboard.nav.agents')}</span>
+                </Link>
+              </li>
+
+              <li className="nav-item">
+                <Link
+                  to={pageRoutes.configurationProfiles()}
+                  className={`${cssNavClass(pageRoutes.configurationProfiles())} ${cssNavBase}`}
                 >
                   <FontAwesomeIcon fixedWidth icon={faCogs} aria-hidden="true" />
                   <span className="pl-2">Configuration Profiles</span>

--- a/app/javascript/components/dashboard/agents/AgentsFilters.jsx
+++ b/app/javascript/components/dashboard/agents/AgentsFilters.jsx
@@ -1,0 +1,158 @@
+import HoverableLabel from 'components/shared/HoverableLabel';
+import ToggleFilters from 'components/shared/ToggleFilters';
+import { i18n } from 'utils/i18n';
+
+const CheckboxFilter = ({ items, selectedItems, updateSelectedItem, setSelectedItems, prefix }) => {
+  const htmlId = (id) => `${prefix}-chk-${id}`;
+
+  return (
+    <>
+      <label
+        className="col-primary cursor-pointer non-selectable mb-3"
+        onClick={() => setSelectedItems([])}
+      >
+        {i18n.t('ui.filters.deselect_all')}
+      </label>
+
+      {items.map((item) => {
+        return (
+          <div className="custom-control custom-checkbox mb-3" key={item.id}>
+            <input
+              type="checkbox"
+              className="custom-control-input desm-custom-control-input"
+              id={htmlId(item.id)}
+              checked={selectedItems.includes(item.id)}
+              onChange={(e) => updateSelectedItem(e.target.value)}
+              value={item.id}
+            />
+            <label className="custom-control-label cursor-pointer" htmlFor={htmlId(item.id)}>
+              {item.name}
+            </label>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+const AgentsFilters = ({ store }) => {
+  const [state, actions] = store;
+
+  const organizationsOptions = () => {
+    const { organizations, selectedOrganizations } = state;
+
+    return (
+      <CheckboxFilter
+        items={organizations}
+        selectedItems={selectedOrganizations}
+        updateSelectedItem={actions.updateSelectedOrganization}
+        setSelectedItems={actions.setSelectedOrganizations}
+        prefix="org"
+      />
+    );
+  };
+
+  const configurationProfilesOptions = () => {
+    const { configurationProfiles, selectedConfigurationProfiles } = state;
+
+    return (
+      <CheckboxFilter
+        items={configurationProfiles}
+        selectedItems={selectedConfigurationProfiles}
+        updateSelectedItem={actions.updateSelectedProfile}
+        setSelectedItems={actions.setSelectedConfigurationProfiles}
+        prefix="cp"
+      />
+    );
+  };
+
+  const statesOptions = () => {
+    const { configurationProfileStates, selectedConfigurationProfileStates } = state;
+
+    return (
+      <CheckboxFilter
+        items={configurationProfileStates}
+        selectedItems={selectedConfigurationProfileStates}
+        updateSelectedItem={actions.updateSelectedState}
+        setSelectedItems={actions.setSelectedConfigurationProfileStates}
+        prefix="st"
+      />
+    );
+  };
+
+  const expandedFilters = () => {
+    return (
+      <>
+        <div className="col-3 mt-3">
+          <div className="card borderless">
+            <div className="card-header bottom-borderless bg-col-secondary">
+              <label className="non-selectable">
+                <strong>{i18n.t('ui.dashboard.agents.filters.organization')}</strong>
+              </label>
+            </div>
+            <div className="card-body bg-col-secondary">{organizationsOptions()}</div>
+          </div>
+        </div>
+        <div className="col-3 mt-3">
+          <div className="card borderless">
+            <div className="card-header bottom-borderless bg-col-secondary">
+              <label className="non-selectable">
+                <strong>{i18n.t('ui.dashboard.agents.filters.configuration_profile')}</strong>
+              </label>
+            </div>
+            <div className="card-body bg-col-secondary">{configurationProfilesOptions()}</div>
+          </div>
+        </div>
+        <div className="col-3 mt-3">
+          <div className="card borderless">
+            <div className="card-header bottom-borderless bg-col-secondary">
+              <label className="non-selectable">
+                <strong>{i18n.t('ui.dashboard.agents.filters.state')}</strong>
+              </label>
+            </div>
+            <div className="card-body bg-col-secondary">{statesOptions()}</div>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const shrinkedFilters = () => {
+    return (
+      <>
+        <div className="col-3 mt-3">
+          <HoverableLabel
+            label={i18n.t('ui.dashboard.agents.filters.organization')}
+            labelCSSClass={'bg-col-secondary'}
+            content={organizationsOptions()}
+          />
+        </div>
+        <div className="col-3 mt-3">
+          <HoverableLabel
+            label={i18n.t('ui.dashboard.agents.filters.configuration_profile')}
+            labelCSSClass={'bg-col-secondary'}
+            content={configurationProfilesOptions()}
+          />
+        </div>
+        <div className="col-3 mt-3">
+          <HoverableLabel
+            label={i18n.t('ui.dashboard.agents.filters.state')}
+            labelCSSClass={'bg-col-secondary'}
+            content={statesOptions()}
+          />
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div className="row top-border-strong bg-col-secondary">
+      <div className="col mt-3">
+        <ToggleFilters showFilters={state.showFilters} toggleFilters={actions.toggleFilters} />
+      </div>
+      {state.showFilters ? expandedFilters() : shrinkedFilters()}
+    </div>
+  );
+};
+
+export default AgentsFilters;

--- a/app/javascript/components/dashboard/agents/AgentsIndex.jsx
+++ b/app/javascript/components/dashboard/agents/AgentsIndex.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo } from 'react';
+import { useLocalStore } from 'easy-peasy';
+import { Link } from 'react-router-dom';
+import useDebounce from 'helpers/useDebounce';
+import { agentsStore } from '../stores/agentsStore';
+import useDidMountEffect from 'helpers/useDidMountEffect';
+import AgentsFilters from './AgentsFilters';
+import SearchBar from './SearchBar';
+import DashboardContainer from '../DashboardContainer';
+import AlertNotice from 'components/shared/AlertNotice';
+import { pageRoutes } from 'services/pageRoutes';
+import { i18n } from 'utils/i18n';
+
+const AgentsIndex = (_props = {}) => {
+  const store = useLocalStore(() => agentsStore());
+  const [state, actions] = store;
+  const searchInput = useDebounce(state.searchInput);
+  const searchParams = useMemo(() => state.filterParams, [
+    state.configurationProfileIds,
+    state.organizationIds,
+    state.configurationProfileIds,
+  ]);
+
+  // fetch data on start and refetch when searchInput/other filters changes
+  useEffect(() => actions.fetchDataFromAPI(), []);
+  useDidMountEffect(() => actions.handleFetchAgents(state.filterParams), [
+    searchInput,
+    state.selectedConfigurationProfiles,
+    state.selectedConfigurationProfileStates,
+    state.selectedOrganizations,
+  ]);
+
+  const profileData = (profile) => (
+    <li key={profile.configurationProfile.id}>
+      <Link key={profile.id} to={pageRoutes.configurationProfile(profile.configurationProfile.id)}>
+        {`${profile.configurationProfile.name} (${profile.configurationProfile.state})`}
+      </Link>
+    </li>
+  );
+  const organizationData = (profile) =>
+    `${profile.organization.name}${profile.leadMapper ? ' (Lead Mapper)' : ''}`;
+  const buildTableRow = (agent) => {
+    const profiles = agent.profiles.map(profileData);
+    const dsos = agent.profiles.map(organizationData);
+    return (
+      <tr key={agent.id}>
+        <td>{agent.name}</td>
+        <td>{agent.email}</td>
+        <td>{agent.phone}</td>
+        <td className="white-space-pre-line">{dsos.join('\n')}</td>
+        <td className="white-space-pre-line">
+          <ul className="list-unstyled">{profiles}</ul>
+        </td>
+      </tr>
+    );
+  };
+
+  return (
+    <DashboardContainer>
+      <div className="col mt-5">
+        <h1>{i18n.t('ui.dashboard.nav.agents')}</h1>
+        <SearchBar search={state.searchInput} updateSearch={actions.setSearchInput} />
+        <AgentsFilters store={store} />
+        {state.hasErrors ? (
+          <AlertNotice message={state.errors} onClose={actions.clearErrors} />
+        ) : null}
+        <div className="table-responsive">
+          <table className="table">
+            <thead>
+              <tr>
+                <th scope="col">{i18n.t('ui.dashboard.agents.table.name')}</th>
+                <th scope="col">{i18n.t('ui.dashboard.agents.table.email')}</th>
+                <th scope="col">{i18n.t('ui.dashboard.agents.table.phone')}</th>
+                <th scope="col">{i18n.t('ui.dashboard.agents.table.organization')}</th>
+                <th scope="col">{i18n.t('ui.dashboard.agents.table.configuration_profile')}</th>
+              </tr>
+            </thead>
+            <tbody>{state.agents.map(buildTableRow)}</tbody>
+          </table>
+        </div>
+      </div>
+    </DashboardContainer>
+  );
+};
+
+export default AgentsIndex;

--- a/app/javascript/components/dashboard/agents/SearchBar.jsx
+++ b/app/javascript/components/dashboard/agents/SearchBar.jsx
@@ -1,0 +1,25 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { i18n } from 'utils/i18n';
+
+const SearchBar = ({ search, updateSearch }) => {
+  return (
+    <div className="row mt-4 justify-content-end">
+      <div className="col-3">
+        <hr className="bottom-border-white" />
+        <div className="form-group input-group-has-icon">
+          <FontAwesomeIcon icon={faSearch} className="form-control-feedback" />
+          <input
+            type="text"
+            className="form-control form-control-lg"
+            placeholder={i18n.t('ui.dashboard.agents.filters.search')}
+            onChange={(e) => updateSearch(e.target.value)}
+            value={search}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/app/javascript/components/dashboard/stores/agentsStore.js
+++ b/app/javascript/components/dashboard/stores/agentsStore.js
@@ -1,0 +1,89 @@
+import { action, computed, thunk } from 'easy-peasy';
+import { pull } from 'lodash';
+import { baseModel } from '../../stores/baseModel';
+import { easyStateSetters } from '../../stores/easyState';
+import fetchAgents from 'services/fetchAgents';
+import fetchAgentsFilters from 'services/fetchAgentsFilters';
+
+export const defaultState = {
+  // status
+  showFilters: false,
+
+  // options
+  searchInput: '',
+  selectedConfigurationProfiles: [],
+  selectedConfigurationProfileStates: [],
+  selectedOrganizations: [],
+
+  // data
+  agents: [],
+  configurationProfiles: [],
+  configurationProfileStates: [],
+  organizations: [],
+};
+
+const updatedFilterFor = (items, id) => {
+  items.includes(id) ? pull(items, id) : items.push(id);
+};
+
+export const agentsStore = (initialData = {}) => ({
+  ...baseModel(initialData),
+  ...easyStateSetters(defaultState, initialData),
+
+  // computed
+  filterParams: computed((state) => {
+    return {
+      search: state.searchInput,
+      configurationProfileIds: state.selectedConfigurationProfiles,
+      configurationProfileStates: state.selectedConfigurationProfileStates,
+      organizationIds: state.selectedOrganizations,
+    };
+  }),
+
+  // actions
+  // set filters
+  setFilters: action((state, filters) => {
+    state.organizations = filters.organizations;
+    state.configurationProfiles = filters.configurationProfiles;
+    state.configurationProfileStates = filters.states;
+  }),
+  toggleFilters: action((state) => {
+    state.showFilters = !state.showFilters;
+  }),
+  updateSelectedOrganization: action((state, id) => {
+    updatedFilterFor(state.selectedOrganizations, parseInt(id));
+  }),
+  updateSelectedProfile: action((state, id) => {
+    updatedFilterFor(state.selectedConfigurationProfiles, parseInt(id));
+  }),
+  updateSelectedState: action((state, id) => {
+    updatedFilterFor(state.selectedConfigurationProfileStates, id);
+  }),
+
+  // thunks
+  // fetch filters
+  handleFetchFilters: thunk(async (actions, _, h) => {
+    const state = h.getState();
+    let response = await fetchAgentsFilters();
+    if (state.withoutErrors(response)) {
+      actions.setFilters(response.filters);
+    } else {
+      actions.addError(response.error);
+    }
+  }),
+  // fetch agents
+  handleFetchAgents: thunk(async (actions, params = {}, h) => {
+    const state = h.getState();
+    let response = await fetchAgents(params);
+    if (state.withoutErrors(response)) {
+      actions.setAgents(response.agents);
+    } else {
+      actions.addError(response.error);
+    }
+  }),
+  // fetch initial data
+  fetchDataFromAPI: thunk(async (actions, _) => {
+    // Get the mapping
+    await Promise.all([actions.handleFetchAgents(), actions.handleFetchFilters()]);
+  }),
+});

--- a/app/javascript/components/dashboard/stores/dashboardStore.js
+++ b/app/javascript/components/dashboard/stores/dashboardStore.js
@@ -1,0 +1,52 @@
+import { action, computed, thunk } from 'easy-peasy';
+import { sum } from 'lodash';
+import { baseModel } from '../../stores/baseModel';
+import { easyStateSetters } from '../../stores/easyState';
+import fetchDashboardStats from 'services/fetchDashboardStats';
+
+export const defaultState = {
+  // options
+  selectedOptionId: 'all',
+
+  // data
+  configurationProfiles: [],
+  filterOptions: [],
+  mappings: [],
+};
+
+export const dashboardStore = (initialData = {}) => ({
+  ...baseModel(initialData),
+  ...easyStateSetters(defaultState, initialData),
+
+  // computed
+  activeMappingsCount: computed((state) => state.mappings.inProgress || 0),
+  filteredCps: computed((state) => {
+    if (state.selectedOptionId === 'all') {
+      return state.configurationProfiles;
+    }
+    return state.configurationProfiles.filter((cp) => cp.state === state.selectedOptionId);
+  }),
+  dsosCount: computed((state) => sum(state.filteredCps.map((cp) => cp.dsosCount))),
+  cpsCount: computed((state) => state.filteredCps.length),
+  agentsCount: computed((state) => sum(state.filteredCps.map((cp) => cp.agentsCount))),
+  schemesCount: computed((state) => sum(state.filteredCps.map((cp) => cp.associatedSchemasCount))),
+
+  // actions
+  setData: action((state, data) => {
+    state.mappings = data.stats.mappings;
+    state.configurationProfiles = data.stats.configurationProfiles;
+    state.filterOptions = data.states;
+  }),
+
+  // thunks
+  // fetch initial data
+  fetchData: thunk(async (actions, _, h) => {
+    const state = h.getState();
+    let response = await fetchDashboardStats();
+    if (state.withoutErrors(response)) {
+      actions.setData(response);
+    } else {
+      actions.addError(response.error);
+    }
+  }),
+});

--- a/app/javascript/components/shared/ToggleFilters.jsx
+++ b/app/javascript/components/shared/ToggleFilters.jsx
@@ -1,0 +1,14 @@
+import { i18n } from 'utils/i18n';
+
+const ToggleFilters = ({ showFilters, toggleFilters }) => {
+  return (
+    <div className="mb-3" onClick={toggleFilters}>
+      <button className="btn btn-dark mr-3">{showFilters ? '▲' : '▼'}</button>
+      <label className="cursor-pointer non-selectable">
+        {i18n.t(`ui.filters.${showFilters ? 'hide' : 'show'}`)}
+      </label>
+    </div>
+  );
+};
+
+export default ToggleFilters;

--- a/app/javascript/helpers/useDebounce.jsx
+++ b/app/javascript/helpers/useDebounce.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = (value, delay = 1000) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/app/javascript/services/api/apiRequest.jsx
+++ b/app/javascript/services/api/apiRequest.jsx
@@ -1,6 +1,6 @@
 import { camelizeKeys, decamelizeKeys } from 'humps';
 import apiService, { processMessage } from './apiService';
-import { chain, pickBy, identity, isNil } from 'lodash';
+import { chain, pickBy, identity, isArray, isEmpty, isNil } from 'lodash';
 /**
  * Manages the api requests
  *
@@ -78,7 +78,14 @@ const queryString = (params) => {
   const queryParams = pickBy(params, identity);
 
   return chain(decamelizeKeys(queryParams))
-    .map((v, k) => (isNil(v) ? null : `${esc(k)}=${esc(v)}`))
+    .map((v, k) => {
+      if (isNil(v)) return null;
+      if (isArray(v)) {
+        if (isEmpty(v)) return null;
+        return v.map((p) => `${esc(k)}[]=${esc(p)}`).join('&');
+      }
+      return `${esc(k)}=${esc(v)}`;
+    })
     .filter()
     .value()
     .join('&');

--- a/app/javascript/services/fetchAgents.jsx
+++ b/app/javascript/services/fetchAgents.jsx
@@ -1,0 +1,14 @@
+import apiRequest from './api/apiRequest';
+
+const fetchAgents = async (queryParams = {}) => {
+  return await apiRequest({
+    url: '/api/v1/agents',
+    method: 'get',
+    defaultResponse: [],
+    successResponse: 'agents',
+    camelizeKeys: true,
+    queryParams: queryParams,
+  });
+};
+
+export default fetchAgents;

--- a/app/javascript/services/fetchAgentsFilters.jsx
+++ b/app/javascript/services/fetchAgentsFilters.jsx
@@ -1,0 +1,13 @@
+import apiRequest from './api/apiRequest';
+
+const fetchAgentsFilters = async () => {
+  return await apiRequest({
+    url: '/api/v1/agents/filters',
+    method: 'get',
+    defaultResponse: [],
+    successResponse: 'filters',
+    camelizeKeys: true,
+  });
+};
+
+export default fetchAgentsFilters;

--- a/app/javascript/services/fetchDashboardStats.jsx
+++ b/app/javascript/services/fetchDashboardStats.jsx
@@ -1,0 +1,12 @@
+import apiRequest from './api/apiRequest';
+
+const fetchDashboardStats = async () => {
+  return await apiRequest({
+    url: '/api/v1/dashboard',
+    method: 'get',
+    defaultResponse: {},
+    camelizeKeys: true,
+  });
+};
+
+export default fetchDashboardStats;

--- a/app/javascript/services/pageRoutes.js
+++ b/app/javascript/services/pageRoutes.js
@@ -1,0 +1,10 @@
+export const pageRoutes = {
+  // dashboard:
+  dashboard: () => '/dashboard',
+  admins: () => '/dashboard/admins',
+  agents: () => '/dashboard/agents',
+  users: () => '/dashboard/users',
+  organizations: () => '/dashboard/organizations',
+  configurationProfiles: () => '/dashboard/configuration-profiles',
+  configurationProfile: (id) => `/dashboard/configuration-profiles/${id}`,
+};

--- a/app/javascript/utils/i18n.js
+++ b/app/javascript/utils/i18n.js
@@ -1,0 +1,4 @@
+import { I18n } from 'i18n-js';
+import translations from '../translations/locales.json';
+
+export const i18n = new I18n(translations);

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -108,8 +108,12 @@ class ConfigurationProfile < ApplicationRecord
     )
   end
 
-  def self.states_for_select
-    ConfigurationProfile.states.keys.map { |state| { id: state, name: state.humanize } }
+  def self.activated_states_for_select
+    ConfigurationProfile.states_for_select(%w(active deactivated))
+  end
+
+  def self.states_for_select(data = ConfigurationProfile.states.keys)
+    data.map { |state| { id: state, name: state.humanize } }
   end
 
   def self.validate_structure(struct, type = "valid")

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -28,6 +28,7 @@
 # @description: Represents an organization in the application
 ###
 class Organization < ApplicationRecord
+  include PgSearch::Model
   include Slugable
 
   belongs_to :administrator, class_name: :User, foreign_key: "administrator_id", optional: true
@@ -40,6 +41,8 @@ class Organization < ApplicationRecord
   has_and_belongs_to_many :configuration_profiles
 
   validates :email, presence: true
+
+  pg_search_scope :search_by_name, against: :name, using: { tsearch: { prefix: true } }
 
   ###
   # @description: Returns the JSON-LD representation of the organization

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@
 # @description: Represents a user of this application
 ###
 class User < ApplicationRecord
+  include PgSearch::Model
   include Tokenable
 
   attr_accessor :skip_sending_welcome_email, :skip_validating_organization
@@ -48,6 +49,35 @@ class User < ApplicationRecord
 
   after_create :send_welcome_email, unless: :skip_sending_welcome_email
   after_save :update_configuration_profiles
+
+  pg_search_scope :search_by_agents,
+                  against: %i(fullname email),
+                  associated_against: {
+                    configuration_profiles: :name,
+                    organizations: :name
+                  },
+                  using: {
+                    tsearch: { prefix: true }
+                  }
+
+  # scope :with_configuration_profiles, -> { where(id: ConfigurationProfileUser.pluck(:user_id)) }
+  scope :with_configuration_profiles, -> { joins(:configuration_profile_users) }
+  # filter by organization ids
+  scope :for_organizations, ->(ids) { joins(:organizations).where(organizations: { id: ids }) }
+  # filter by configuration profile ids
+  scope :for_configuration_profiles, lambda { |ids|
+    joins(:configuration_profiles)
+      .where(configuration_profiles: { id: ids })
+  }
+  # filter by configuration profile states
+  scope :for_configuration_profile_states, lambda { |states|
+    joins(:configuration_profiles).where(configuration_profiles: { state: states })
+  }
+
+  def self.search_with_configuration_profiles(query)
+    joins(configuration_profiles: :configuration_profile_users)
+      .merge(ConfigurationProfile.search_by_name(query))
+  end
 
   def as_json(options = {})
     super(options.merge(methods: %i(roles)))

--- a/app/policies/admin_access_policy.rb
+++ b/app/policies/admin_access_policy.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+###
+# @description: Represents the ability that only admin can acess the data
+###
+class AdminAccessPolicy < ApplicationPolicy
+  ###
+  # @description: Determines if the user can see this resource
+  # @return [TrueClass]
+  ###
+  def show?
+    signed_in? && admin_role?
+  end
+
+  ###
+  # @description: Determines if the user can create an instance of this resource
+  # @return [TrueClass]
+  ###
+  def create?
+    signed_in? && admin_role?
+  end
+
+  ###
+  # @description: Determines if the user can update an instance of this resource
+  # @return [TrueClass]
+  ###
+  def update?
+    signed_in? && admin_role?
+  end
+
+  ###
+  # @description: Determines if the user can destroy an instance of this resource
+  # @return [TrueClass]
+  ###
+  def destroy?
+    signed_in? && admin_role?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.all if user.user.super_admin?
+
+      scope.none
+    end
+  end
+end

--- a/app/policies/agent_policy.rb
+++ b/app/policies/agent_policy.rb
@@ -2,7 +2,7 @@
 
 ###
 # @description: Represents the ability that a user has to access
-#   organization records.
+#   agents records.
 ###
-class OrganizationPolicy < AdminAccessPolicy
+class AgentPolicy < AdminAccessPolicy
 end

--- a/app/policies/configuration_profile_policy.rb
+++ b/app/policies/configuration_profile_policy.rb
@@ -2,7 +2,7 @@
 
 ###
 # @description: Represents the ability that a user has to access
-#   organization records.
+#   configuration profiles records.
 ###
-class OrganizationPolicy < AdminAccessPolicy
+class ConfigurationProfilePolicy < AdminAccessPolicy
 end

--- a/app/queries/agents_query.rb
+++ b/app/queries/agents_query.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AgentsQuery < BaseQuery
+  def call
+    apply_filters
+    sorted_scope
+  end
+
+  private
+
+  def apply_filters
+    return if q.empty?
+
+    @scope = scope.with_configuration_profiles
+    @scope = scope.for_organizations(q.organization_ids) if q.organization_ids.present?
+    @scope = scope.for_configuration_profiles(q.configuration_profile_ids) if q.configuration_profile_ids.present?
+    @scope = scope.for_configuration_profile_states(q.configuration_profile_states) \
+      if q.configuration_profile_states.present?
+
+    return unless q.search.present?
+
+    search_scope = with_joins? ? User.where(id: @scope.ids) : @scope
+    @scope = search_scope.search_by_agents(q.search)
+  end
+
+  def sorted_scope
+    # we need the `reorder("")` for this to work with DISTINCT
+    # See more on: https://github.com/Casecommons/pg_search/issues/238
+    scope.reorder("").order(fullname: :asc).distinct
+  end
+
+  def with_joins?
+    q.organization_ids.present? || q.configuration_profile_ids.present? || q.configuration_profile_states.present?
+  end
+end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BaseQuery
+  def self.call(scope, params: {}, pagination: nil)
+    new(scope, params:, pagination:).call
+  end
+
+  def initialize(scope, params: {}, pagination: nil)
+    @scope = scope
+    @q = NormalizedParams.new(params)
+    @pagination = pagination
+  end
+
+  private
+
+  attr_reader :q, :scope, :pagination
+
+  def apply_filters
+    raise NotImplementedError
+  end
+
+  def sorted_scope
+    raise NotImplementedError
+  end
+end

--- a/app/queries/dashboard_stats_query.rb
+++ b/app/queries/dashboard_stats_query.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DashboardStatsQuery < BaseQuery
+  def call
+    {
+      configuration_profiles:,
+      mappings:
+    }
+  end
+
+  private
+
+  def associated_schemas_count_for(profile)
+    (profile.structure["standards_organizations"] || []).map { |org| org["associated_schemas"]&.size || 0 }.sum
+  end
+
+  def configuration_profiles
+    ConfigurationProfile.all.map do |profile|
+      {
+        id: profile.id,
+        name: profile.name,
+        state: profile.state,
+        dsos_count: organization_count_for(profile),
+        agents_count: agents_count_for(profile),
+        associated_schemas_count: associated_schemas_count_for(profile)
+      }
+    end
+  end
+
+  def organization_count_for(profile)
+    # TODO: uncomment when we will be sure on what is primary source for cp data
+    # return profile.standards_organizations.count if profile.activated?
+    profile.structure["standards_organizations"]&.size || 0
+  end
+
+  def agents_count_for(profile)
+    # TODO: uncomment when we will be sure on what is primary source for cp data
+    # return profile.configuration_profile_users.count if profile.activated?
+    (profile.structure["standards_organizations"] || []).map { |org| org["dso_agents"]&.size || 0 }.sum
+  end
+
+  def mappings
+    Mapping.all.group(:status).count
+  end
+end

--- a/app/serializers/agent_serializer.rb
+++ b/app/serializers/agent_serializer.rb
@@ -3,8 +3,32 @@
 # subset of user attributes
 class AgentSerializer < ApplicationSerializer
   attributes :email, :fullname, :github_handle, :organization_id, :phone
+  attribute :profiles, if: -> { params[:with_configuration_profiles] }
 
   attribute :name do
     object.fullname
+  end
+
+  # TODO: this need to be updated when we will have more roles
+  def role
+    Desm::MAPPER_ROLE_NAME
+  end
+
+  def profiles
+    data = object.configuration_profile_users.includes(:configuration_profile, :organization).map do |profile_user|
+      configuration_profile = profile_user.configuration_profile
+      organization = profile_user.organization
+      { id: profile_user.id,
+        lead_mapper: profile_user.lead_mapper,
+        configuration_profile: {
+          name: configuration_profile.name, id: configuration_profile.id,
+          state: configuration_profile.state
+        },
+        organization: {
+          name: organization.name,
+          id: organization.id
+        } }
+    end
+    data.sort_by { |profile| profile[:organization][:name] }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module App
 
     config.autoload_paths += [
       Rails.root.join("app", "interacotrs", "concerns"),
+      Rails.root.join("lib", "utils"),
     ]
   end
 end

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -1,0 +1,5 @@
+---
+translations:
+  - file: app/javascript/translations/locales.json
+    patterns:
+      - "*.ui.*"

--- a/config/i18n_export.rb
+++ b/config/i18n_export.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rails"
+require "active_support/railtie"
+require "action_view/railtie"
+
+I18n.load_path += Dir["./config/locales/**/*.yml"]

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,6 @@
+if Rails.env.development?
+  Rails.application.config.after_initialize do
+    require "i18n-js/listen"
+    I18nJS.listen
+  end
+end

--- a/config/locales/ui/en.yml
+++ b/config/locales/ui/en.yml
@@ -3,3 +3,24 @@ en:
     config:
       user:
         phone_format: "should be at least 6 characters long and can contain digits, spaces, or hyphens, optionally starting with a plus sign. Examples: +1234567890, 123-456-789, 123 456 7890"
+    filters:
+      show: Show Filters
+      hide: Hide Filters
+      deselect_all: Deselect All
+      hide_all: Hide All
+      show_all: Show All
+    dashboard:
+      nav:
+        agents: Agents
+      agents:
+        table:
+          name: Name
+          email: Email
+          phone: Phone
+          organization: DSO(s)
+          configuration_profile: Profile(s)
+        filters:
+          organization: Filter Agents for DSO(s)
+          configuration_profile: Filter Agents for Profile(s)
+          state: Filter Agents for Profile's State
+          search: Search Agents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,10 +137,14 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
+      resources :agents, only: :index do
+        get :filters, on: :collection
+      end
       resources :alignments, only: [:destroy, :index, :update]
       resources :alignment_vocabulary_concepts, only: [:update]
       resources :alignment_synthetic_concepts, only: [:create]
       resources :audits, only: [:index]
+      resources :dashboard, only: [:index]
       resources :domains, only: [:index, :show]
       resources :mappings, only: [:create, :destroy, :show, :index, :update]
       resources :merged_files, only: [:create, :show]

--- a/lib/utils/normalized_params.rb
+++ b/lib/utils/normalized_params.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class NormalizedParams < OpenStruct # rubocop:todo Style/OpenStructUse
+  def initialize(params)
+    params = params.dup.to_h
+    params.deep_transform_keys! { |key| key.to_s.underscore.to_sym }
+    params.deep_transform_values! do |value|
+      case value
+      when "true"
+        true
+      when "false"
+        false
+      else
+        value
+      end
+    end
+
+    super(params)
+  end
+end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "codemirror": "^5.57.0",
     "easy-peasy": "^6.0.4",
     "humps": "^2.0.1",
+    "i18n-js": "^4.4.3",
     "is-valid-json": "^1.0.2",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",

--- a/spec/queries/agents_query_spec.rb
+++ b/spec/queries/agents_query_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentsQuery do
+  let(:scope) { User.all }
+  let(:params) { {} }
+
+  subject { described_class.call(scope, params:) }
+
+  describe "#call" do
+    context "without data" do
+      it "returns a empty relation" do
+        expect(subject).to be_a(ActiveRecord::Relation)
+      end
+    end
+
+    context "with data" do
+      let!(:user1) { create(:user) }
+      let!(:user2) { create(:user) }
+      let!(:org1) { create(:organization) }
+      let!(:org2) { create(:organization) }
+      let!(:cp1) { create(:configuration_profile, :active) }
+      let!(:cp2) { create(:configuration_profile, :deactivated) }
+
+      before do
+        # user1 in cp1 (org1, org2) and cp2 (org2)
+        create(:configuration_profile_user, user: user1, configuration_profile: cp1, organization: org1)
+        create(:configuration_profile_user, user: user1, configuration_profile: cp2, organization: org2)
+        # user2 in cp2 (org2)
+        create(:configuration_profile_user, user: user2, configuration_profile: cp2, organization: org2)
+      end
+
+      context "without filters" do
+        it "returns a relation with all users" do
+          expect(subject).to include(user1, user2)
+        end
+      end
+
+      context "with filter by organization" do
+        let(:params) { { organization_ids: [org1.id] } }
+
+        it "returns a relation with the users in the organization" do
+          expect(subject).to include(user1)
+        end
+      end
+
+      context "with filter by configuration profile" do
+        let(:params) { { configuration_profile_ids: [cp2.id] } }
+
+        it "returns a relation with the users in the configuration profile" do
+          expect(subject).to include(user1, user2)
+        end
+      end
+
+      context "with search" do
+        let(:params) { { search: user1.fullname } }
+
+        it "returns a relation with the users that match the search" do
+          expect(subject).to include(user1)
+        end
+      end
+
+      context "with search and filters" do
+        let(:params) { { search: user1.fullname, organization_ids: [org1.id] } }
+
+        it "returns a relation with the users that match the search and the organization" do
+          expect(subject).to include(user1)
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/dashboard_stats_query_spec.rb
+++ b/spec/queries/dashboard_stats_query_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DashboardStatsQuery do
+  let(:scope) { User }
+
+  subject { described_class.new(scope).call }
+
+  describe "#call" do
+    it "returns a hash with configuration_profiles and mappings" do
+      expect(subject).to be_a(Hash)
+      expect(subject).to have_key(:configuration_profiles)
+      expect(subject).to have_key(:mappings)
+    end
+  end
+end

--- a/spec/queries/normalized_params_spec.rb
+++ b/spec/queries/normalized_params_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe NormalizedParams do
+  describe "#initialize" do
+    it "converts keys to underscore" do
+      q = described_class.new("fooBar" => "baz")
+      expect(q.foo_bar).to eq("baz")
+    end
+
+    it "converts values to boolean (true)" do
+      q = described_class.new("fooBar" => "true")
+      expect(q.foo_bar).to eq(true)
+    end
+
+    it "converts values to boolean (false)" do
+      q = described_class.new("fooBar" => "false")
+      expect(q.foo_bar).to eq(false)
+    end
+
+    it "does not convert values when not boolean" do
+      q = described_class.new("fooBar" => 1)
+      expect(q.foo_bar).to eq(1)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,11 @@ big.js@^5.2.2:
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@*:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz"
@@ -4750,6 +4755,15 @@ humps@^2.0.1:
   resolved "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz"
   integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
+i18n-js@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.4.3.tgz#09744ddd377261f614502cc5622ce6981026ea4a"
+  integrity sha512-QIIyvJ+wOKdigL4BlgwiFFrpoXeGdlC8EYgori64YSWm1mnhNYYjIfRu5wETFrmiNP2fyD6xIjVG8dlzaiQr/A==
+  dependencies:
+    bignumber.js "*"
+    lodash "*"
+    make-plural "*"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
@@ -5741,6 +5755,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@*:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz"
@@ -5786,6 +5805,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-plural@*:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-7.3.0.tgz#2889dbafca2fb097037c47967d3e3afa7e48a52c"
+  integrity sha512-/K3BC0KIsO+WK2i94LkMPv3wslMrazrQhfi5We9fMbLlLjzoOSJWr7TAdupLlDWaJcWxwoNosBkhFDejiu5VDw==
 
 map-cache@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
#345

* Added Agents view with list of agents and filters + links on agents to main dashboard. Text search is done by agents fullname, email and organization&configuration profile names.
* Updated main dashboard to load faster
* Introduced I18n support for js

**Important:**
_on data_
Agents are shown only for active/deactivated configuration profiles as we're querying from DB and only for active configuration profiles data is there.
Main dashboard stats is based on internal configuration profile structure (nothing new, it was based on this previously) and as structure isn't synced with db data there may be some inconsistency on that. Anyway number will be different and after sync too as we're showing only created users at agents.
_on UX_
All existing agents will be shown on load, same as we have for other pages. This may cause issues if there will be more data and we need to move to pagination model for mappings list/agents. Also there is no sorting support as it has to be done for all table views at once.