### PR TITLE
[hotfix] fixed predicate labels contrast

### DIFF
--- a/app/assets/stylesheets/base/_colors.scss
+++ b/app/assets/stylesheets/base/_colors.scss
@@ -44,20 +44,20 @@ $desm-predicate-colors: (
     text: $black,
   ),
   lime-green: (
-    bg: #28a745,
+    bg: #1e7e34,
     text: $white,
   ),
   orange: (
     bg: #ffa500,
-    text: $white,
+    text: $black,
   ),
   red: (
-    bg: #dc3545,
+    bg: #b02a37,
     text: $white,
   ),
   pink: (
     bg: #ff4c23,
-    text: $white,
+    text: $black,
   ),
   yellow: (
     bg: #c3c300,


### PR DESCRIPTION
This pull request includes changes to the color scheme in the `_colors.scss` file to improve the visual contrast and accessibility of the application.

Color scheme updates:

* [`app/assets/stylesheets/base/_colors.scss`](diffhunk://#diff-4bfff47d958d79016dfd89caf0055a375ba25e0b823bda81d4fb954dceaa301bL47-R60): Updated the background color for `lime-green` from `#28a745` to `#1e7e34` to improve contrast.
* [`app/assets/stylesheets/base/_colors.scss`](diffhunk://#diff-4bfff47d958d79016dfd89caf0055a375ba25e0b823bda81d4fb954dceaa301bL47-R60): Changed the text color for `orange` from `$white` to `$black` to enhance readability.
* [`app/assets/stylesheets/base/_colors.scss`](diffhunk://#diff-4bfff47d958d79016dfd89caf0055a375ba25e0b823bda81d4fb954dceaa301bL47-R60): Modified the background color for `red` from `#dc3545` to `#b02a37` for better visual distinction.
* [`app/assets/stylesheets/base/_colors.scss`](diffhunk://#diff-4bfff47d958d79016dfd89caf0055a375ba25e0b823bda81d4fb954dceaa301bL47-R60): Adjusted the text color for `pink` from `$white` to `$black` to improve text visibility.