### PR TITLE
[hotfix] fixed vocabulary mapping modal

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -9,3 +9,4 @@
 @import 'components/predicate';
 @import 'components/sidebar-toggle';
 @import 'components/toggle';
+@import 'components/vocabulary';

--- a/app/assets/stylesheets/components/_vocabulary.scss
+++ b/app/assets/stylesheets/components/_vocabulary.scss
@@ -1,0 +1,6 @@
+.desm-vocabulary-mapping {
+  &.ReactModal__Content {
+    margin-right: -95% !important; // stylelint-disable-line declaration-no-important
+    width: 95% !important; // stylelint-disable-line declaration-no-important;
+  }
+}

--- a/app/javascript/components/align-and-fine-tune/match-vocabulary/MatchVocabulary.jsx
+++ b/app/javascript/components/align-and-fine-tune/match-vocabulary/MatchVocabulary.jsx
@@ -405,6 +405,7 @@ export default class MatchVocabulary extends Component {
         isOpen={modalIsOpen}
         onRequestClose={onRequestClose}
         contentLabel="Match Controlled Vocabulary"
+        className="desm-vocabulary-mapping"
         style={ModalStyles}
         shouldCloseOnEsc={false}
         shouldCloseOnOverlayClick={false}

--- a/app/javascript/components/align-and-fine-tune/match-vocabulary/SpineConceptRow.jsx
+++ b/app/javascript/components/align-and-fine-tune/match-vocabulary/SpineConceptRow.jsx
@@ -42,7 +42,7 @@ const SpineConceptRow = (props) => {
       <div className="col-4">
         <PredicateOptions
           predicates={predicates}
-          onPredicateSelected={(predicate) => onPredicateSelected(predicate)}
+          onPredicateSelected={onPredicateSelected}
           predicate={predicateLabel}
         />
       </div>

--- a/app/serializers/term_serializer.rb
+++ b/app/serializers/term_serializer.rb
@@ -3,7 +3,7 @@
 class TermSerializer < ApplicationSerializer
   attributes :comments, :compact_domains, :compact_ranges, :raw, :source_uri, :slug, :uri
   has_one :property
-  has_many :vocabularies, unless: -> { params[:spine] }, serializer: PreviewSerializer
+  has_many :vocabularies, serializer: PreviewSerializer
   has_one :organization, if: -> { params[:with_organization] }, serializer: PreviewSerializer
 
   attribute :specification_ids, if: -> { params[:specification_ids] } do


### PR DESCRIPTION
This pull request includes several changes to the styling and functionality of the vocabulary mapping components, as well as a minor simplification in a JavaScript function and an update to a serializer in the backend.

Styling and functionality updates:

* [`app/assets/stylesheets/_components.scss`](diffhunk://#diff-cf69a372e9e9b02d4ac6c6bb0cd8360017f870c83dc094d096e9d64625dd2a9aR12): Added import for new vocabulary styles.
* [`app/assets/stylesheets/components/_vocabulary.scss`](diffhunk://#diff-3a22c627f07ec63d4d53533ee64b0d2bb715e9213e90040e6f4ab4563acee01bR1-R6): Added styles for the vocabulary mapping modal to adjust its width and margin.
* [`app/javascript/components/align-and-fine-tune/match-vocabulary/MatchVocabulary.jsx`](diffhunk://#diff-f4df7e0615812e67dea0cbe1cefc1d6544968ef2d21cf7a527b1ab92506e6769R408): Applied the new vocabulary mapping styles to the modal component.

Code simplification:

* [`app/javascript/components/align-and-fine-tune/match-vocabulary/SpineConceptRow.jsx`](diffhunk://#diff-b7dee620e1651192716db3bf30c341b20a9c0f91a4b5dfd17a660ea8bc98d83aL45-R45): Simplified the `onPredicateSelected` function by removing the unnecessary arrow function.

Serializer update:

* [`app/serializers/term_serializer.rb`](diffhunk://#diff-3dd0ed3bcc4569d88d5a26fa02831dc91095149161c758a8d69f70ce773dfa6bL6-R6): Updated the `has_many :vocabularies` association to always use the `PreviewSerializer`, removing the conditional check.