### PR TITLE
(#664) fixed removing spine term with nomatch

### DIFF
--- a/app/models/alignment.rb
+++ b/app/models/alignment.rb
@@ -130,6 +130,13 @@ class Alignment < ApplicationRecord
     false
   end
 
+  def mapped?
+    # if no match predicate is set, we consider the alignment as not mapped and can be removed
+    return false if predicate&.source_uri.present? && predicate.source_uri.downcase.include?("nomatch")
+
+    completed?
+  end
+
   ###
   # @description: Notify the user about changes on the mapping
   ###

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -117,7 +117,7 @@ class Term < ApplicationRecord
 
   def check_if_alignments_exist
     return if alignments.none?
-    return if (alignments_completed = alignments.includes(:predicate).select(&:completed?)).blank?
+    return if (alignments_completed = alignments.includes(:predicate).select(&:mapped?)).blank?
 
     mappings = alignments_completed.map { |a| a.mapping.title }.uniq.sort
 

--- a/spec/models/alignment_spec.rb
+++ b/spec/models/alignment_spec.rb
@@ -101,6 +101,27 @@ describe Alignment do
     end
   end
 
+  describe "#mapped?" do
+    it "returns if alignment is mapped" do
+      term = create(:term)
+      predicate = create(:predicate)
+      predicate2 = create(:predicate, :nomatch)
+      alignment1 = create(:alignment, spine_term: term, mapped_terms: [term], predicate:)
+      alignment2 = create(:alignment, predicate:, spine_term: term)
+      alignment3 = create(:alignment, predicate:, spine_term: term, synthetic: true)
+      alignment4 = create(:alignment, predicate:, spine_term: term, synthetic: false)
+      alignment5 = create(:alignment, predicate: predicate2, spine_term: term, synthetic: true)
+
+      mapped_alignments = term.alignments.select(&:mapped?)
+
+      expect(mapped_alignments).to include(alignment1)
+      expect(mapped_alignments).not_to include(alignment5)
+      expect(mapped_alignments).not_to include(alignment2)
+      expect(mapped_alignments).not_to include(alignment3)
+      expect(mapped_alignments).not_to include(alignment4)
+    end
+  end
+
   describe "methods" do
     xit "calls notify_updated on mapping when notify_mapping_updated is called" do
       mapping = create(:mapping)

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -34,13 +34,20 @@ describe Term do
   describe "#destroy" do
     it "raises an error if the term has completed alignments" do
       term = create(:term)
-      predicate = create(:predicate, :nomatch)
-      create(:alignment, spine_term: term, predicate:)
+      create(:alignment, spine_term: term, mapped_terms: [create(:term)])
 
       expect { term.destroy }.to raise_error(RuntimeError)
     end
 
-    it "destroys the term if it doesn't have completed alignments" do
+    it "destroys the term if it has no mapped alignments" do
+      term = create(:term)
+      predicate = create(:predicate, :nomatch)
+      create(:alignment, spine_term: term, predicate:)
+
+      expect { term.destroy }.to change { Term.count }.by(-1)
+    end
+
+    it "destroys the term if it doesn't have mapped alignments" do
       term = create(:term)
       create(:alignment, spine_term: term)
 


### PR DESCRIPTION
#664

This pull request allows to remove spine term if no attached mapping or mappings with no match predicate.

### Changes to models:

* [`app/models/alignment.rb`](diffhunk://#diff-cdf85eabe969aba9d894b32320e6a8c53940e3141dd11fb22ea6368335fe2a3dR133-R139): Added a new method `mapped?` to determine if an alignment is mapped based on the presence and content of the `predicate.source_uri`.
* [`app/models/term.rb`](diffhunk://#diff-3dcda8d15c57cd9147a46438e60e00e69c7ef93240daf9e7795379e9e8621d97L120-R120): Updated the `check_if_alignments_exist ` method to use the new `mapped?` method instead of `completed?` to check for mapped alignments

### Changes to specs:

* [`spec/models/alignment_spec.rb`](diffhunk://#diff-a65ef30c5001ecf2727459187e417645dcfb8073c7b8a15f262e127d95abd221R104-R124): Added a new test for the `mapped?` method to verify its behavior with different predicates and alignment configurations.
* [`spec/models/term_spec.rb`](diffhunk://#diff-362078ed0f16681bd42c11cac9da95f9d6350b6b580f7f32753d91a5709b66e3R36-R50): Updated existing tests and added new ones to ensure correct behavior when destroying terms based on the presence of mapped alignments.